### PR TITLE
feat: module overrides and defaults

### DIFF
--- a/lib/make-system.nix
+++ b/lib/make-system.nix
@@ -15,55 +15,17 @@
 , name
 , system
 , config
+, defaultModules ? import ../modules/list.nix
+, extraModules ? []
 }:
 with nixpkgs.lib;
 let
-  defaultModules = [
-    ../modules/runit
-    ../modules/dumb-init
-    ../modules/initrd
-    ../modules/init.nix
-    ../modules/system.nix
-    ../modules/assertions.nix
-    ../modules/bootloader
-    ../modules/nix.nix
-
-    ../modules/security/ca.nix
-
-    ../modules/misc/iana.nix
-
-    ../modules/environment.nix
-    ../modules/users.nix
-    ../modules/ids.nix
-
-    ../modules/services/apache2-nixos.nix
-    ../modules/services/nginx.nix
-    ../modules/services/gitea.nix
-    ../modules/services/getty.nix
-    ../modules/services/socklog.nix
-    ../modules/services/crond.nix
-    ../modules/services/hydra.nix
-    ../modules/services/postgresql.nix
-    ../modules/services/mysql.nix
-    ../modules/services/certbot.nix
-    ../modules/services/postfix.nix
-    ../modules/services/dovecot.nix
-    ../modules/services/pantalaimon.nix
-    ../modules/services/jmusicbot.nix
-    ../modules/services/php-fpm.nix
-    ../modules/services/minecraft.nix
-    ../modules/services/home-assistant.nix
-    ../modules/services/zigbee2mqtt.nix
-    ../modules/services/mosquitto.nix
-    ../modules/services/syncthing.nix
-    ({ ... }: {
-      system.name = name;
-    })
-  ];
-
   evaledModules = evalModules
     {
-      modules = defaultModules ++ [
+      modules = defaultModules ++ extraModules ++ [
+        ({ ... }: {
+          system.name = name;
+        })
         config
         ({ ... }:
           {

--- a/modules/list.nix
+++ b/modules/list.nix
@@ -1,0 +1,39 @@
+[
+    ./runit
+    ./dumb-init
+    ./initrd
+    ./init.nix
+    ./system.nix
+    ./assertions.nix
+    ./bootloader
+    ./nix.nix
+
+    ./security/ca.nix
+
+    ./misc/iana.nix
+
+    ./environment.nix
+    ./users.nix
+    ./ids.nix
+
+    ./services/apache2-nixos.nix
+    ./services/nginx.nix
+    ./services/gitea.nix
+    ./services/getty.nix
+    ./services/socklog.nix
+    ./services/crond.nix
+    ./services/hydra.nix
+    ./services/postgresql.nix
+    ./services/mysql.nix
+    ./services/certbot.nix
+    ./services/postfix.nix
+    ./services/dovecot.nix
+    ./services/pantalaimon.nix
+    ./services/jmusicbot.nix
+    ./services/php-fpm.nix
+    ./services/minecraft.nix
+    ./services/home-assistant.nix
+    ./services/zigbee2mqtt.nix
+    ./services/mosquitto.nix
+    ./services/syncthing.nix
+]


### PR DESCRIPTION
This PR adds some feature parity with the "make system" portion of NixNG and nixOS. Default modules are added to `modules/list.nix` and extra modules can be added in the `extraModules` attribute for "make-system".