### PR TITLE
fix: flake check now works

### DIFF
--- a/examples/nix/default.nix
+++ b/examples/nix/default.nix
@@ -19,7 +19,7 @@ nglib.makeSystem {
     };
     nix = {
       enable = true;
-      package = pkgs.nixVersions.stable;
+      package = pkgs.nixStable;
       config = {
         experimental-features = [ "nix-command" "flakes" ];
         sandbox = false;


### PR DESCRIPTION
This fixes an example which relies on an attribute which no longer exists in `nixpkgs`. There's one more issue with nodejs v12 being used with zigbee2mqtt but that should be fixed in `nixpkgs` already.