### PR TITLE
feat: system packages work

### DIFF
--- a/modules/dumb-init/default.nix
+++ b/modules/dumb-init/default.nix
@@ -89,6 +89,7 @@ in
           let
             runit = pkgs.writeShellScript "init"
               ''
+                set -n
                 export PATH=${pkgs.busybox}/bin
                 _system_config="@systemConfig@"
 
@@ -98,6 +99,7 @@ in
               '';
             shell = pkgs.writeShellScript "init"
               ''
+                set -n
                 export PATH=${pkgs.busybox}/bin:${pkgs.bash}/bin
                 _system_config="@systemConfig@"
 

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -20,7 +20,8 @@ let
   makeShellWrapper = pkg: name:
     let
       script = pkgs.writeShellScriptBin name ''
-        export PATH="$PATH"':${makeBinPath cfg.systemPackages}'
+        set -n
+        source /etc/profile
         exec ${pkg}/bin/${name} "$@"
       '';
     in "${script}/bin/${name}";

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -26,7 +26,8 @@ let
     in "${script}/bin/${name}";
 
   shells = if cfg.shell.enable then ({
-    bash = (makeShellWrapper pkgs.bash "bash");
+    bash = (makeShellWrapper pkgs.bashInteractive "bash");
+    sh = (makeShellWrapper pkgs.bashInteractive "bash");
   }) else ({
     sh = "${pkgs.busybox}/bin/sh";
   });

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -28,8 +28,6 @@ let
   shells = if cfg.shell.enable then ({
     bash = (makeShellWrapper pkgs.bashInteractive "bash");
     sh = (makeShellWrapper pkgs.bashInteractive "bash");
-  }) else ({
-    sh = "${pkgs.busybox}/bin/sh";
   });
 in
 {

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -28,7 +28,7 @@ let
   shells = if cfg.shell.enable then ({
     bash = (makeShellWrapper pkgs.bashInteractive "bash");
     sh = (makeShellWrapper pkgs.bashInteractive "bash");
-  });
+  }) else ({});
 in
 {
   options.environment = {

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -33,10 +33,13 @@ let
     pkgs.zstd
   ];
 
-  makeShellWrapper = pkg: name: pkgs.writeShellScriptBin name ''
-    source /etc/profile
-    exec ${pkg}/bin/${name} "$@"
-  '';
+  makeShellWrapper = pkg: name:
+    let
+      script = pkgs.writeShellScriptBin name ''
+        export PATH="$PATH"':${makeBinPath cfg.systemPackages}'
+        exec ${pkg}/bin/${name} "$@"
+      '';
+    in "${script}/bin/${name}";
 
   shells = if cfg.shell.enable then ({
     bash = (makeShellWrapper pkgs.bash "bash");

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -14,23 +14,7 @@ let
 
   requiredPackages = map (pkg: setPrio ((pkg.meta.priority or 5) + 3) pkg) [
     pkgs.bashInteractive
-    pkgs.coreutils-full
-    pkgs.diffutils
-    pkgs.findutils
-    pkgs.gawk
-    pkgs.gnugrep
-    pkgs.gnused
-    pkgs.gnutar
-    pkgs.gzip
-    pkgs.xz
-    pkgs.less
-    pkgs.ncurses
-    pkgs.procps
-    pkgs.su
-    pkgs.time
-    pkgs.util-linux
-    pkgs.which
-    pkgs.zstd
+    pkgs.busybox
   ];
 
   makeShellWrapper = pkg: name:

--- a/modules/services/apache2-nixos.nix
+++ b/modules/services/apache2-nixos.nix
@@ -80,6 +80,8 @@ in
           enabled = true;
         };
 
+      environment.systemPackages = with pkgs; [ cfg.package ];
+
       users.users."www-data" = mkIf cfg.createUserGroup {
         description = "Apache HTTPD";
         group = "www-data";

--- a/modules/services/certbot.nix
+++ b/modules/services/certbot.nix
@@ -114,6 +114,8 @@ in
       }
     ];
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     system.activation.certbot = nglib.dag.dagEntryAfter
       [ "createbaseenv" "users" ]
       (concatStringsSep "\n" (mapAttrsToList

--- a/modules/services/crond.nix
+++ b/modules/services/crond.nix
@@ -103,5 +103,7 @@ in
         '';
         enabled = true;
       };
+
+    environment.systemPackages = with pkgs; [ cfg.package ];
   };
 }

--- a/modules/services/dovecot.nix
+++ b/modules/services/dovecot.nix
@@ -136,6 +136,8 @@ in
         gid = ids.gids.dovenull;
       };
 
+      environment.systemPackages = with pkgs; [ cfg.package ];
+
       services.dovecot = {
         config = {
           default_login_user = mkIf (cfg.loginUser != null) cfg.loginUser;

--- a/modules/services/gitea.nix
+++ b/modules/services/gitea.nix
@@ -221,6 +221,8 @@ in
       enabled = true;
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     users.users."gitea" = mkIf (cfg.enable && cfg.user == defaultUser) {
       uid = ids.uids.gitea;
       description = "Gitea user";

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -95,6 +95,8 @@ in
       enabled = true;
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     users.users.${cfg.user} = mkDefaultRec {
       description = "Home Assistant";
       group = cfg.group;

--- a/modules/services/hydra.nix
+++ b/modules/services/hydra.nix
@@ -376,6 +376,7 @@ in
       };
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
     environment.variables = hydraEnv;
 
     init.services = {

--- a/modules/services/jmusicbot.nix
+++ b/modules/services/jmusicbot.nix
@@ -94,6 +94,8 @@ in
       gid = mkDefault config.ids.gids.jmusicbot;
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     init.services.jmusicbot =
       {
         script = pkgs.writeShellScript "jmusicbot-run"

--- a/modules/services/minecraft.nix
+++ b/modules/services/minecraft.nix
@@ -140,6 +140,8 @@ in
         enabled = true;
       };
 
+    environment.systemPackages = with pkgs; [ cfg.javaPackage cfg.overlayfsPackage ];
+
     assertions = [
       { assertion = cfg.eulaAccept;
         message = "You must accept the EULA";

--- a/modules/services/mosquitto.nix
+++ b/modules/services/mosquitto.nix
@@ -112,6 +112,8 @@ in
       enabled = true;
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     users.users.${cfg.user} = mkDefaultRec {
       description = "mosquitto";
       group = cfg.group;

--- a/modules/services/mysql.nix
+++ b/modules/services/mysql.nix
@@ -206,6 +206,8 @@ in
 
       users.groups.mysql.gid = config.ids.gids.mysql;
 
+      environment.systemPackages = with pkgs; [ cfg.package ];
+
       init.services.mysql = {
         ensureSomething.create."dataDir" = {
           type = "directory";

--- a/modules/services/nginx.nix
+++ b/modules/services/nginx.nix
@@ -88,6 +88,8 @@ in
           enabled = true;
         };
 
+      environment.systemPackages = with pkgs; [ cfg.package ];
+
       users.users.${cfg.user} = mkDefaultRec {
         description = "Nginx";
         group = cfg.group;

--- a/modules/services/pantalaimon.nix
+++ b/modules/services/pantalaimon.nix
@@ -76,6 +76,8 @@ in
       gid = mkDefault config.ids.gids.pantalaimon;
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     init.services.pantalaimon =
       {
         ensureSomething.create."dataDir" = {

--- a/modules/services/postfix.nix
+++ b/modules/services/postfix.nix
@@ -207,6 +207,8 @@ in
         gid = mkDefault config.ids.gids.postdrop;
       };
 
+      environment.systemPackages = with pkgs; [ cfg.package ];
+
       services.postfix = {
         mainConfig = {
           compatibility_level = mkDefault cfg.package.version;

--- a/modules/services/postgresql.nix
+++ b/modules/services/postgresql.nix
@@ -274,6 +274,8 @@ in
   # END Copyright (c) 2003-2021 Eelco Dolstra and the Nixpkgs/NixOS contributors
 
   config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     # BEGIN Copyright (c) 2003-2021 Eelco Dolstra and the Nixpkgs/NixOS contributors
     services.postgresql.config = {
       hba_file = "${pkgs.writeText "pg_hba.conf" cfg.authentication}";

--- a/modules/services/socklog.nix
+++ b/modules/services/socklog.nix
@@ -64,6 +64,8 @@ in
         enabled = true;
       };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     assertions = [
       {
         assertion = !(cfg.unix == null && cfg.inet == null);

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -71,6 +71,8 @@ in
         '';
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     users.users.${cfg.user} = mkDefaultRec {
       description = "Syncthing";
       group = cfg.group;

--- a/modules/services/zigbee2mqtt.nix
+++ b/modules/services/zigbee2mqtt.nix
@@ -81,6 +81,8 @@ in
       enabled = true;
     };
 
+    environment.systemPackages = with pkgs; [ cfg.package ];
+
     users.users.${cfg.user} = mkDefaultRec {
       description = "zigbee2mqtt";
       group = cfg.group;

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -167,7 +167,8 @@ in
               cat << EOF > /run/current-system/sw/bin/$(basename $exec)
 #!${pkgs.busybox}/bin/sh
 
-export PATH="$PATH"':${makeBinPath config.environment.systemPackages}'
+set -n
+source /etc/profile
 exec $exec "\$@"
 EOF
               chmod +x /run/current-system/sw/bin/$(basename $exec)

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -162,7 +162,7 @@ in
         mkdir -p /run/current-system/sw/bin
         ${concatStringsSep "\n" (map (pkg:
           ''
-            execs=${pkgs.findutils}/bin/find ${pkg}/bin -type f
+            execs=$(${pkgs.findutils}/bin/find ${pkg}/bin -type f)
             for exec in $execs; do
               ln -sf $exec /run/current-system/sw/bin
             done

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -158,6 +158,16 @@ in
 
         mkdir -p /run
         ln -s $_system_config /run/current-system
+
+        mkdir -p /run/current-system/sw/bin
+        ${concatStringsSep "\n" (map (pkg:
+          ''
+            execs=${pkgs.findutils}/bin/find ${pkg}/bin -type f
+            for exec in $execs; do
+              ln -sf $exec /run/current-system/sw/bin
+            done
+          ''
+        ) config.environment.systemPackages)}
       '';
 
     system.activationScript = pkgs.writeShellScript "activation"

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -164,7 +164,13 @@ in
           ''
             execs=$(${pkgs.findutils}/bin/find ${pkg}/bin -type f)
             for exec in $execs; do
-              ln -sf $exec /run/current-system/sw/bin
+              cat << EOF > /run/current-system/sw/bin/$(basename $exec)
+#!${pkgs.busybox}/bin/sh
+
+export PATH="$PATH"':${makeBinPath config.environment.systemPackages}'
+exec $exec "\$@"
+EOF
+              chmod +x /run/current-system/sw/bin/$(basename $exec)
             done
           ''
         ) config.environment.systemPackages)}


### PR DESCRIPTION
This implements similar behavior as nixOS's activation script where it places all system package executables in
`/run/current-system/sw/bin`. This also wraps shells in `/bin` so they may work by automatically sourcing `/etc/profile`.