### PR TITLE
feat: add default file for lib

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -25,4 +25,4 @@ let
       "syncthing" = ./syncthing;
     };
 in
-  nixpkgs.lib.mapAttrs (_: v: import v { nglib = nglib nixpkgs.lib; inherit nixpkgs; }) examples
+  nixpkgs.lib.mapAttrs (_: v: import v { inherit nixpkgs nglib; }) examples

--- a/flake.nix
+++ b/flake.nix
@@ -20,18 +20,8 @@
         import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
     in
     {
-      nglib =
-        lib:
-        let this =
-              { makeSystem = import ./lib/make-system.nix { nglib = this; overlay = self.overlays.default;  };
-                dag = import ./lib/dag.nix { inherit lib; };
-                generators = import ./lib/generators.nix { inherit lib; };
-                mkDefaultRec = lib.mapAttrsRecursive (_: v: lib.mkDefault v);
-              };
-        in this;
-
+      nglib = import ./lib nixpkgs.lib;
       examples = import ./examples { inherit nixpkgs; inherit (self) nglib; };
-
       overlays.default = import ./overlay;
 
       devShells = forAllSystems (system:

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,8 @@
+lib:
+let this =
+  { makeSystem = import ./make-system.nix { nglib = this; overlay = import ../overlay;  };
+    dag = import ./dag.nix { inherit lib; };
+    generators = import ./generators.nix { inherit lib; };
+    mkDefaultRec = lib.mapAttrsRecursive (_: v: lib.mkDefault v);
+  };
+in this


### PR DESCRIPTION
This PR adds `lib/default.nix` and moves the `nglib` definition to that file. A change has also been made so `nglib` will automatically pull lib from `nixpkgs` without having to specify it.