### PR TITLE
fix: impure nixpkgs import

### DIFF
--- a/lib/make-system.nix
+++ b/lib/make-system.nix
@@ -30,7 +30,7 @@ let
         ({ ... }:
           {
             _module.args = {
-              pkgs = import nixpkgs { inherit system; overlays = [ overlay ]; };
+              pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [ overlay ];
               inherit system nglib;
             };
           }


### PR DESCRIPTION
This PR replaces any direct imports of the `nixpkgs` Flake and uses the recommended `legacyPackages` attribute to pull `nixpkgs`. The overlay is also added correctly with `appendOverlays`.