### PR TITLE
do not assume presence of /etc/php.ini file in php package

### DIFF
--- a/modules/services/php-fpm.nix
+++ b/modules/services/php-fpm.nix
@@ -199,7 +199,7 @@ in
               pkgs.writeShellScript "php-fpm-${pool}-run"
                 ''
                   echo HELLO
-                  ${opts.package}/bin/php-fpm -y ${phpFpmConfFile} -c ${phpIniFile}
+                  ${opts.package.php}/bin/php-fpm -y ${phpFpmConfFile} -c ${phpIniFile}
                 '';
           }
         )

--- a/modules/services/php-fpm.nix
+++ b/modules/services/php-fpm.nix
@@ -25,7 +25,7 @@ let
       preferLocalBuild = true;
     }
     ''
-      cat ${package}/etc/php.ini $phpGlobalSettingsPath $phpSettingsPath > $out
+      cat $phpGlobalSettingsPath $phpSettingsPath > $out
     '';
 
   genFpmConfFile = { settings }: pkgs.runCommandNoCC "php-fpm.conf"


### PR DESCRIPTION
fixes #31. 

When using different package builders like https://github.com/loophp/nix-php-composer-builder, they dont necessarily produce a php ini file