### PR TITLE
Get rid of usages of `with lib;` and `with nglib;`

### DIFF
--- a/checks/with-lib.nix
+++ b/checks/with-lib.nix
@@ -1,0 +1,22 @@
+{ ripgrep
+, runCommand
+, self
+, lib
+}:
+{ allowed ? []
+}:
+let
+  allowed' = lib.pipe allowed [
+    (map (lib.replaceStrings ["."] ["\."]))
+    (lib.concatStringsSep "|")
+  ];
+in
+runCommand "with-lib-check.sh" {
+  nativeBuildInputs = [
+    ripgrep
+  ];
+} ''
+  [ "$(rg "with lib;" -n ${self} | rg -v "${allowed'}" | tee with-lib.rg | wc -l)" -le 1 ] \
+    || ( cat with-lib.rg ; exit 1 ) \
+    && exit 0
+''

--- a/checks/with-lib.nix
+++ b/checks/with-lib.nix
@@ -3,20 +3,21 @@
 , self
 , lib
 }:
-{ allowed ? []
+{ allowed ? [ ]
 }:
 let
   allowed' = lib.pipe allowed [
-    (map (lib.replaceStrings ["."] ["\."]))
+    (map (lib.replaceStrings [ "." ] [ "\." ]))
     (lib.concatStringsSep "|")
   ];
 in
-runCommand "with-lib-check.sh" {
+runCommand "with-lib-check.sh"
+{
   nativeBuildInputs = [
     ripgrep
   ];
 } ''
-  [ "$(rg "with lib;" -n ${self} | rg -v "${allowed'}" | tee with-lib.rg | wc -l)" -le 1 ] \
-    || ( cat with-lib.rg ; exit 1 ) \
+  [ "$(rg "with lib;" -n ${self} | rg -v "${allowed'}" | tee $out | wc -l)" -le 1 ] \
+    || ( cat $out ; exit 1 ) \
     && exit 0
 ''

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -9,7 +9,8 @@
 { nglib, nixpkgs, nixng }:
 let
   examples =
-    { "gitea" = ./gitea;
+    {
+      "gitea" = ./gitea;
       "gitea-sane" = ./gitea/sane.nix;
       "apache" = ./apache;
       "nginx" = ./nginx;
@@ -28,4 +29,4 @@ let
       "attic" = ./attic;
     };
 in
-  nixpkgs.lib.mapAttrs (_: v: import v { inherit nixpkgs nglib nixng; }) examples
+nixpkgs.lib.mapAttrs (_: v: import v { inherit nixpkgs nglib nixng; }) examples

--- a/flake.nix
+++ b/flake.nix
@@ -35,24 +35,25 @@
           pkgs = import nixpkgs { inherit system; overlays = [ (import ./overlay) ]; };
           lib = pkgs.lib;
         in
-          lib.genAttrs (lib.attrNames (import ./overlay null null)) (packageName: pkgs.${packageName}));
+        lib.genAttrs (lib.attrNames (import ./overlay null null)) (packageName: pkgs.${packageName}));
 
       packages = forAllSystems (system:
         let
           lib = nixpkgs.lib;
         in
-          lib.filterAttrs (_: v: lib.isDerivation v) self.legacyPackages.${system}
+        lib.filterAttrs (_: v: lib.isDerivation v) self.legacyPackages.${system}
       );
 
       devShells = forAllSystems (system:
         let pkgs = pkgsForSystem system;
         in
-          { default = pkgs.mkShell {
-              nativeBuildInputs = with pkgs;
-                [
-                ];
-            };
-          });
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs;
+              [
+              ];
+          };
+        });
 
       checks = {
         examples = recurseIntoAttrs (nixpkgs.lib.mapAttrs (n: v: v.config.system.build.toplevel) self.examples);
@@ -60,13 +61,13 @@
         let
           pkgs = pkgsForSystem system;
         in
-          {
-            with-lib = pkgs.callPackage ./checks/with-lib.nix { inherit self; } {
-              allowed = [
-                "/doc/style_and_vocabulary.org"
-                "/checks"
-              ];
-            };
-          });
+        {
+          with-lib = pkgs.callPackage ./checks/with-lib.nix { inherit self; } {
+            allowed = [
+              "/doc/style_and_vocabulary.org"
+              "/checks"
+            ];
+          };
+        });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,17 @@
 
       checks = {
         examples = recurseIntoAttrs (nixpkgs.lib.mapAttrs (n: v: v.config.system.build.toplevel) self.examples);
-      };
+      } // forAllSystems (system:
+        let
+          pkgs = pkgsForSystem system;
+        in
+          {
+            with-lib = pkgs.callPackage ./checks/with-lib.nix { inherit self; } {
+              allowed = [
+                "/doc/style_and_vocabulary.org"
+                "/checks"
+              ];
+            };
+          });
     };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,12 @@
 lib:
-let this =
-  { makeSystem = import ./make-system.nix { nglib = this; overlay = import ../overlay;  };
+let
+  inherit
+    (lib)
+    types
+    ;
+  this =
+  {
+    makeSystem = import ./make-system.nix { nglib = this; overlay = import ../overlay;  };
     dag = import ./dag.nix { inherit lib; };
     generators = import ./generators.nix { inherit lib; };
     mkDefaultRec = lib.mapAttrsRecursive (_: v: lib.mkDefault v);
@@ -10,34 +16,10 @@ let this =
         applied = fun x;
       };
 
-    mkTmpfilesOption = name: description:
-      lib.mkOption {
-        default = {};
-        type = with lib.types;
-          attrsOf (listOf (listOf str));
-        description = ''
-          A lists of lists. The first list corresponds to the individual entries
-          and the most inner one corresponds to the individual fields in use by `tmpfiles.conf`.
-
-          ${description}
-        '';
-        example = ''
-          [
-            # Type  Path          Mode   User   Group   Age   Argument...
-            [ "d"     "/run/user"   "0755" "root" "root"  "10d" "-" ]
-            [ "L"     "/tmp/foobar" "-"    "-"    "-"     "-"   "/dev/null" ]
-          ]
-        '';
-        apply = with lib;
-          this.mkApply (x:
-            pkgs.writeText name
-              (concatMapStringsSep "\n" (concatStringsSep " ")));
-      };
-
     mkDagOption = description:
       lib.mkOption {
         inherit description;
-        type = with lib.types; attrsOf (submodule {
+        type = types.attrsOf (types.submodule {
           options = {
             data = lib.mkOption {
               description = ''

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -7,7 +7,21 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { lib }:
-with lib;
+let
+  inherit
+    (lib)
+    isAttrs
+    concatStringsSep
+    concatMapStringsSep
+    mapAttrsToList
+    isString
+    isInt
+    isStorePath
+    isList
+    isBool
+    all
+    ;
+in
 rec {
   toApache = cfg:
     if isAttrs cfg then

--- a/lib/make-system.nix
+++ b/lib/make-system.nix
@@ -18,8 +18,14 @@
 , defaultModules ? import ../modules/list.nix
 , extraModules ? []
 }:
-with nixpkgs.lib;
 let
+  inherit
+    (nixpkgs.lib)
+    evalModules
+    filter
+    concatStringsSep
+    ;
+
   evaledModules = evalModules
     {
       specialArgs = {

--- a/modules/assertions.nix
+++ b/modules/assertions.nix
@@ -7,7 +7,13 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { lib, ... }:
-with lib;
+let
+  inherit
+    (lib)
+    mkOption
+    types
+    ;
+in
 {
   options.assertions = mkOption {
     description = "List of assertions";

--- a/modules/bootloader/default.nix
+++ b/modules/bootloader/default.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { config, lib, ... }:
-with lib;
 let
   cfg = config.bootloader;
 
@@ -39,27 +38,27 @@ let
 in
 {
   options.bootloader = {
-    enable = mkEnableOption "Enable the bootloader";
-    kernelExtraConfig = mkOption {
+    enable = lib.mkEnableOption "Enable the bootloader";
+    kernelExtraConfig = lib.mkOption {
       description = "";
-      type = types.attrsOf (types.enum [ "y" "n" "m" ]);
+      type = with lib.types; attrsOf (enum [ "y" "n" "m" ]);
       default = { };
     };
 
-    initrdCompression = mkOption {
+    initrdCompression = lib.mkOption {
       description = "Supported compression algorithms for initrd";
-      type = types.listOf (types.enum (builtins.attrNames initrdAlgos));
+      type = with lib.types; listOf (enum (builtins.attrNames initrdAlgos));
       default = [ ];
     };
 
-    filesystems = mkOption {
+    filesystems = lib.mkOption {
       description = "Supported filesystems for initrd";
-      type = types.listOf (types.enum (builtins.attrNames filesystems));
+      type = with lib.types; listOf (enum (builtins.attrNames filesystems));
       default = [ ];
     };
   };
 
-  config.bootloader = mkIf cfg.enable {
+  config.bootloader = lib.mkIf cfg.enable {
     kernelExtraConfig =
       (builtins.listToAttrs
         (map

--- a/modules/dumb-init/default.nix
+++ b/modules/dumb-init/default.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, ... }:
-with lib;
 let
   cfg = config.dumb-init;
   cfgRunit = config.runit;
@@ -27,36 +26,36 @@ let
 in
 {
   options.dumb-init = {
-    enable = mkEnableOption "Enable the dumb-init init system";
+    enable = lib.mkEnableOption "Enable the dumb-init init system";
 
-    package = mkOption {
+    package = lib.mkOption {
       description = "The dumb-init package to use";
-      type = types.package;
+      type = lib.types.package;
       default = pkgs.dumb-init;
     };
 
-    sigell = mkOption {
+    sigell = lib.mkOption {
       description = ''
         A signal rewriting program, which allows to redirect,
         rewrite and handle signals easily
       '';
-      type = with types; nullOr (attrs);
+      type = with lib.types; nullOr attrs;
       default = null;
     };
 
-    type = mkOption {
+    type = lib.mkOption {
       description = "Which type of stage 2 init to run";
-      type = types.submodule {
+      type = lib.types.submodule {
         options = {
-          services = mkOption {
+          services = lib.mkOption {
             description = "Run the runit stage-2 script to start runsvdir and all the services.";
-            type = with types; nullOr (submodule { });
+            type = with lib.types; nullOr (submodule { });
             default = null;
           };
 
-          shell = mkOption {
+          shell = lib.mkOption {
             description = "Run a bash shell, without any services.";
-            type = with types; nullOr (submodule {
+            type = with lib.types; nullOr (submodule {
               options = {
                 user = mkOption {
                   description = "Which user to start the shell under.";
@@ -73,11 +72,11 @@ in
   };
 
   config = {
-    init = mkMerge [
+    init = lib.mkMerge [
       {
         availableInits = [ "dumb-init" ];
       }
-      (mkIf cfg.enable {
+      (lib.mkIf cfg.enable {
         type = "dumb-init";
         shutdown = pkgs.writeShellScript "dum-init-shutdown"
           ''
@@ -133,7 +132,7 @@ in
               if cfg.sigell != null then
                 "${pkgs.sigell}/bin/sigell ${sigellConfig { command = cmd; }}"
               else
-                concatStringsSep " " cmd;
+                lib.concatStringsSep " " cmd;
           in
           if cfg.type.services != null then
             runit
@@ -144,12 +143,12 @@ in
       })
     ];
 
-    assertions = mkIf cfg.enable ([
+    assertions = lib.mkIf cfg.enable ([
       {
-        assertion = count (x: x) (mapAttrsToList (n: v: v != null) cfg.type) == 1;
+        assertion = lib.count (x: x) (lib.mapAttrsToList (n: v: v != null) cfg.type) == 1;
         message = "Please select exactly one dumb-init type.";
       }
-    ] ++ (optional (cfg.type.shell != null)
+    ] ++ (lib.optional (cfg.type.shell != null)
       {
         assertion = cfgUsers.users ? "${cfg.type.shell.user}";
         message = "User ${cfg.type.shell.user} does not exist!";

--- a/modules/dumb-init/default.nix
+++ b/modules/dumb-init/default.nix
@@ -57,7 +57,7 @@ in
             description = "Run a bash shell, without any services.";
             type = with lib.types; nullOr (submodule {
               options = {
-                user = mkOption {
+                user = lib.mkOption {
                   description = "Which user to start the shell under.";
                   type = str;
                   default = "root";

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -16,7 +16,7 @@ in
       default = { };
       example = { EDITOR = "vim"; BROWSER = "firefox"; };
       type = with lib.types; attrsOf (either str (listOf str));
-      apply = lib.mkApply
+      apply = nglib.mkApply
         (x: lib.concatStringsSep " "
           (lib.mapAttrsToList (n: v: "${n}=" + (if lib.isList v then lib.concatStringsSep ":" v else v)) x));
     };
@@ -34,7 +34,7 @@ in
           Shell script fragments, concataned into /etc/profile.
         '';
         type = with lib.types; listOf str;
-        apply = lib.mkApply
+        apply = nglib.mkApply
           (x: pkgs.writeShellScript "profile" (lib.concatStringsSep "\n" x));
         default = [ ];
       };

--- a/modules/environment.nix
+++ b/modules/environment.nix
@@ -7,52 +7,51 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, nglib, ... }:
-with lib; with nglib;
 let
   cfg = config.environment;
 in
 {
   options.environment = {
-    variables = mkOption {
+    variables = lib.mkOption {
       default = { };
       example = { EDITOR = "vim"; BROWSER = "firefox"; };
-      type = with types; attrsOf (either str (listOf str));
-      apply = mkApply
-        (x: concatStringsSep " "
-          (mapAttrsToList (n: v: "${n}=" + (if isList v then concatStringsSep ":" v else v)) x));
+      type = with lib.types; attrsOf (either str (listOf str));
+      apply = lib.mkApply
+        (x: lib.concatStringsSep " "
+          (lib.mapAttrsToList (n: v: "${n}=" + (if lib.isList v then lib.concatStringsSep ":" v else v)) x));
     };
 
     shell = {
-      enable = mkOption {
+      enable = lib.mkOption {
         description = ''
           Enable the packages needed to get a shell.
         '';
-        type = types.bool;
+        type = lib.types.bool;
         default = true;
       };
-      profile = mkOption {
+      profile = lib.mkOption {
         description = ''
           Shell script fragments, concataned into /etc/profile.
         '';
-        type = with types; listOf str;
-        apply = mkApply
-          (x: pkgs.writeShellScript "profile" (concatStringsSep "\n" x));
+        type = with lib.types; listOf str;
+        apply = lib.mkApply
+          (x: pkgs.writeShellScript "profile" (lib.concatStringsSep "\n" x));
         default = [ ];
       };
     };
 
-    createBaseEnv = mkOption {
+    createBaseEnv = lib.mkOption {
       description = ''
         Create /bin/sh, /usr/bin/env, /var/empty, and /tmp.
       '';
-      type = types.bool;
+      type = lib.types.bool;
       default = true;
     };
 
-    systemPackages = mkOption {
+    systemPackages = lib.mkOption {
       description = "Packages globally added to PATH";
       default = [ ];
-      type = with types; listOf package;
+      type = with lib.types; listOf package;
     };
   };
 
@@ -61,8 +60,8 @@ in
 
     environment.shell.profile = [
       ''
-        ${optionalString (cfg.variables.applied != "") "export ${cfg.variables.applied}"}
-        export PATH="$PATH"':${makeBinPath cfg.systemPackages}'
+        ${lib.optionalString (cfg.variables.applied != "") "export ${cfg.variables.applied}"}
+        export PATH="$PATH"':${lib.makeBinPath cfg.systemPackages}'
       ''
     ];
 
@@ -74,7 +73,7 @@ in
       mv /etc/.profile.tmp /etc/profile # atomically replace /etc/profile
     '';
 
-    system.activation.createBaseEnv = mkIf cfg.createBaseEnv
+    system.activation.createBaseEnv = lib.mkIf cfg.createBaseEnv
       (nglib.dag.dagEntryAnywhere
         ''
           export PATH=${pkgs.busybox}/bin

--- a/modules/fstab.nix
+++ b/modules/fstab.nix
@@ -7,49 +7,48 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { lib, config, ... }:
-with lib;
 let
   cfg = config.fstab;
 
-  supportedFileSystems = flip genAttrs (const false) cfg.supportedFileSystems;
-  missingFileSystems = filter
+  supportedFileSystems = lib.flip lib.genAttrs (lib.const false) cfg.supportedFileSystems;
+  missingFileSystems = lib.filter
     (x: supportedFileSystems.${x} or true)
-    (mapAttrsToList (_: x: x.type) cfg.entries);
+    (lib.mapAttrsToList (_: x: x.type) cfg.entries);
 
   entryOption.options = {
-    device = mkOption {
-      type = types.str;
+    device = lib.mkOption {
+      type = lib.types.str;
       description = ''
         The device to mount.
       '';
     };
 
-    type = mkOption {
-      type = types.str;
+    type = lib.mkOption {
+      type = lib.types.str;
       description = ''
         Type of the filesystem to be mounted.
       '';
     };
 
-    options = mkOption {
-      type = with types;
+    options = lib.mkOption {
+      type = with lib.types;
         listOf str;
       description = ''
         Options for mounting the filesystem.
       '';
-      default = [];
+      default = [ ];
     };
 
-    dump = mkOption {
-      type = types.bool;
+    dump = lib.mkOption {
+      type = lib.types.bool;
       description = ''
         Used by dump(8) to determined which filesystems need to be dumped.
       '';
       default = false;
     };
 
-    fsck = mkOption {
-      type = types.int;
+    fsck = lib.mkOption {
+      type = lib.types.int;
       description = ''
         Used by fsck(8) to determine the order in which filesystems need to be checked. The root filesystem
         should have value 1, all the rest should have value 2. If the value is 0, fsck is disabled for that
@@ -61,21 +60,21 @@ let
 in
 {
   options.fstab = {
-    supportedFileSystems = mkOption {
-      type = with types;
+    supportedFileSystems = lib.mkOption {
+      type = with lib.types;
         listOf str;
       description = ''
         List of filesystems that are supported by the system.
       '';
       default = [ "ext4" ];
     };
-    entries = mkOption {
-      type = with types;
+    entries = lib.mkOption {
+      type = with lib.types;
         attrsOf (submodule entryOption);
       description = ''
         fstab entries to be mounted at boot.
       '';
-      default = {};
+      default = { };
     };
   };
 
@@ -83,13 +82,13 @@ in
     assertions = [
       # check that every entry in fstab uses a supported filesystem type
       {
-        assertion = missingFileSystems == [];
-        message = "Unsupported filesystems ${concatStringsSep "," missingFileSystems} in `fstab.entries`";
+        assertion = missingFileSystems == [ ];
+        message = "Unsupported filesystems ${lib.concatStringsSep "," missingFileSystems} in `fstab.entries`";
       }
       # check that the value for the fsck field is one of [ 0, 1, 2 ]
       {
         assertion =
-          foldl (acc: a: acc && (a == 0 || a == 1 || a == 2)) true (mapAttrsToList (_: v: v.fsck) cfg.entries);
+          lib.foldl (acc: a: acc && (a == 0 || a == 1 || a == 2)) true (lib.mapAttrsToList (_: v: v.fsck) cfg.entries);
         message = "Invalid fsck field value in `fstab.entries`";
       }
     ];

--- a/modules/ids.nix
+++ b/modules/ids.nix
@@ -7,16 +7,15 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { lib, ... }:
-with lib;
 {
   options.ids = {
-    uids = mkOption {
+    uids = lib.mkOption {
       description = "A username to uid map, used for keeping track of assigned uids.";
-      type = with types; attrsOf int;
+      type = with lib.types; attrsOf int;
     };
-    gids = mkOption {
+    gids = lib.mkOption {
       description = "A groupname to gid map, used for keeping track of assigned gids.";
-      type = with types; attrsOf int;
+      type = with lib.types; attrsOf int;
     };
   };
 

--- a/modules/init.nix
+++ b/modules/init.nix
@@ -7,24 +7,23 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { lib, config, ... }:
-with lib;
 let
   cfg = config.init;
 
-  log = mkOption {
+  log = lib.mkOption {
     description = "Logging settings.";
-    type = with types; nullOr (submodule ({ config, ... }:
+    type = with lib.types; nullOr (submodule ({ config, ... }:
       {
         options = {
-          file = mkOption {
+          file = lib.mkOption {
             description = "Log to a plain file, without rotation.";
             type = nullOr (submodule {
               options = {
-                dst = mkOption {
+                dst = lib.mkOption {
                   description = "The file to which to log to.";
                   type = path;
                 };
-                rotate = mkOption {
+                rotate = lib.mkOption {
                   description = "The size after which the file should rotated in kilo bytes.";
                   type = int;
                   default = 0; # 1 MB
@@ -41,35 +40,35 @@ let
               in
               {
                 options = {
-                  type = mkOption {
+                  type = lib.mkOption {
                     description = "Syslog type, UDS, TCP, or UDP.";
                     type = enum [ "uds" "tcp" "udp" ];
                   };
-                  dst = mkOption {
+                  dst = lib.mkOption {
                     description = "The endpoint to log to, format depends on the type.";
                     type = str;
                   };
-                  time = mkOption {
+                  time = lib.mkOption {
                     description = "Whether the complete sender timestamp should be included in log messages";
                     type = bool;
                     default = false;
                   };
-                  host = mkOption {
+                  host = lib.mkOption {
                     description = "Whether the hostname should be included in log messages.";
                     type = bool;
                     default = true;
                   };
-                  timeQuality = mkOption {
+                  timeQuality = lib.mkOption {
                     description = "Whether time quality information should be included in the log messages.";
                     type = bool;
                     default = false;
                   };
-                  tag = mkOption {
+                  tag = lib.mkOption {
                     description = "Every message will be marked with this tag.";
                     type = nullOr str;
                     default = null;
                   };
-                  priority = mkOption {
+                  priority = lib.mkOption {
                     description = "Mark every message with a priority.";
                     type = nullOr str;
                     default = null;
@@ -79,9 +78,9 @@ let
                 config = {
                   dst =
                     if cfg.type == "uds" then
-                      mkDefault "/dev/log"
+                      lib.mkDefault "/dev/log"
                     else if cfg.type == "tcp" || cfg.type == "udp" then
-                      mkDefault "127.0.0.1:514"
+                      lib.mkDefault "127.0.0.1:514"
                     else
                       abort "Unknown syslog type, this should have been caught by the module system!";
                 };
@@ -93,24 +92,24 @@ let
       }));
     default = { };
   };
-  ensureSomething = mkOption {
+  ensureSomething = lib.mkOption {
     description = "Files or directories which need to exist before service is started, no overwriting though.";
     default = { };
-    type = with types;
+    type = with lib.types;
       submodule {
         options = {
-          link = mkOption {
+          link = lib.mkOption {
             type = attrsOf (submodule {
               options = {
-                src = mkOption {
+                src = lib.mkOption {
                   description = "The source of the link.";
                   type = path;
                 };
-                dst = mkOption {
+                dst = lib.mkOption {
                   description = "The destination of the link.";
                   type = path;
                 };
-                persistent = mkOption {
+                persistent = lib.mkOption {
                   description = "Whether the created something should be kept after service stop.";
                   type = bool;
                   default = false;
@@ -119,18 +118,18 @@ let
             });
             default = { };
           };
-          copy = mkOption {
+          copy = lib.mkOption {
             type = attrsOf (submodule {
               options = {
-                src = mkOption {
+                src = lib.mkOption {
                   description = "The source of the copy.";
                   type = path;
                 };
-                dst = mkOption {
+                dst = lib.mkOption {
                   description = "The destination of copy.";
                   type = path;
                 };
-                persistent = mkOption {
+                persistent = lib.mkOption {
                   description = "Whether the created something should be kept after service stop.";
                   type = bool;
                   default = false;
@@ -140,18 +139,18 @@ let
             });
             default = { };
           };
-          linkFarm = mkOption {
+          linkFarm = lib.mkOption {
             type = attrsOf (submodule {
               options = {
-                src = mkOption {
+                src = lib.mkOption {
                   description = "The source of the link farm.";
                   type = path;
                 };
-                dst = mkOption {
+                dst = lib.mkOption {
                   description = "The destination of the link farm.";
                   type = path;
                 };
-                persistent = mkOption {
+                persistent = lib.mkOption {
                   description = "Whether the created something should be kept after service stop.";
                   type = bool;
                   default = false;
@@ -160,19 +159,19 @@ let
             });
             default = { };
           };
-          exec = mkOption {
+          exec = lib.mkOption {
             description = "Execute file to create a file or directory.";
             type = attrsOf (submodule {
               options = {
-                dst = mkOption {
+                dst = lib.mkOption {
                   description = "Where should the executable output and what file or folder to check whether it should be run.";
                   type = path;
                 };
-                executable = mkOption {
+                executable = lib.mkOption {
                   description = "The path to the executable to execute. Use $out.";
                   type = path;
                 };
-                persistent = mkOption {
+                persistent = lib.mkOption {
                   description = "Whether the created something should be kept after service stop.";
                   type = bool;
                   default = false;
@@ -181,29 +180,29 @@ let
             });
             default = { };
           };
-          create = mkOption {
+          create = lib.mkOption {
             description = "Creates either an empty file or directory.";
             type = attrsOf (submodule {
               options = {
-                type = mkOption {
+                type = lib.mkOption {
                   description = "Whether to create a direcotroy or file.";
                   type = enum [ "directory" "file" ];
                 };
-                mode = mkOption {
+                mode = lib.mkOption {
                   description = "Mode to set for the new creation, if set to `null`, its up to the implementation.";
                   default = null;
                   type = nullOr str;
                 };
-                owner = mkOption {
+                owner = lib.mkOption {
                   description = "Owner of new creation.";
                   default = "root:root";
                   type = str;
                 };
-                dst = mkOption {
+                dst = lib.mkOption {
                   description = "Wheret to create it.";
                   type = path;
                 };
-                persistent = mkOption {
+                persistent = lib.mkOption {
                   description = "Whether the created something should be kept after service stop.";
                   type = bool;
                   default = false;
@@ -218,67 +217,67 @@ let
 in
 {
   options.init = {
-    type = mkOption {
+    type = lib.mkOption {
       description = "Selected init system.";
-      type = types.enum cfg.type;
+      type = lib.types.enum cfg.type;
     };
-    availableInits = mkOption {
+    availableInits = lib.mkOption {
       description = "List of available init systems.";
-      type = types.listOf types.str;
+      type = with lib.types; listOf str;
     };
-    script = mkOption {
+    script = lib.mkOption {
       description = "init script.";
-      type = types.path;
+      type = lib.types.path;
     };
-    shutdown = mkOption {
+    shutdown = lib.mkOption {
       description = "A script which successfully shuts down the system.";
-      type = types.path;
+      type = lib.types.path;
     };
-    services = mkOption {
-      type = types.attrsOf (types.submodule {
+    services = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule {
         options = {
-          dependencies = mkOption {
+          dependencies = lib.mkOption {
             description = "Service dependencies";
-            type = types.listOf (types.str);
+            type = with lib.types; listOf str;
             default = [ ];
           };
 
           inherit ensureSomething log;
 
-          shutdownOnExit = mkEnableOption "Whether the init system should enter shutdown when this particular service exits";
+          shutdownOnExit = lib.mkEnableOption "Whether the init system should enter shutdown when this particular service exits";
 
-          script = mkOption {
+          script = lib.mkOption {
             description = "Service script to start the program.";
-            type = types.path;
+            type = lib.types.path;
             default = "";
           };
 
-          finish = mkOption {
+          finish = lib.mkOption {
             description = "Script to run upon service stop.";
-            type = with types; nullOr path;
+            type = with lib.types; nullOr path;
             default = null;
           };
 
-          enabled = mkOption {
+          enabled = lib.mkOption {
             description = "Whether the service should run on startup.";
-            type = types.bool;
+            type = lib.types.bool;
             default = false;
           };
 
-          environment = mkOption {
+          environment = lib.mkOption {
             description = ''
               The environment variables that will be added to the default ones prior to running <option>script</option>
               and <option>finish</option>.
             '';
-            type = with types; attrsOf (oneOf [ str int ]);
+            type = with lib.types; attrsOf (oneOf [ str int ]);
             default = { };
           };
 
-          pwd = mkOption {
+          pwd = lib.mkOption {
             description = ''
               Directory in which both <option>script</option> and <option>finish</option> will be ran.
             '';
-            type = types.str;
+            type = lib.types.str;
             default = "/var/empty";
           };
         };
@@ -290,13 +289,13 @@ in
 
   config = {
     # TODO add assertions for this module
-    assertions = flatten (mapAttrsToList
+    assertions = lib.flatten (lib.mapAttrsToList
       (n: v:
         [{
           assertion =
             let
               selectedCount =
-                (count (x: x) (mapAttrsToList (n: v: if v == null then false else true) v.log));
+                (lib.count (x: x) (lib.mapAttrsToList (n: v: if v == null then false else true) v.log));
             in
             selectedCount == 1 || selectedCount == 0;
           message = "You can only select one log type, in service ${n}.";

--- a/modules/init.nix
+++ b/modules/init.nix
@@ -12,29 +12,29 @@ let
 
   log = lib.mkOption {
     description = "Logging settings.";
-    type = with lib.types; nullOr (submodule ({ config, ... }:
+    type = lib.types.nullOr (lib.types.submodule ({ config, ... }:
       {
         options = {
           file = lib.mkOption {
             description = "Log to a plain file, without rotation.";
-            type = nullOr (submodule {
+            type = lib.types.nullOr (lib.types.submodule {
               options = {
                 dst = lib.mkOption {
                   description = "The file to which to log to.";
-                  type = path;
+                  type = lib.types.path;
                 };
                 rotate = lib.mkOption {
                   description = "The size after which the file should rotated in kilo bytes.";
-                  type = int;
+                  type = lib.types.int;
                   default = 0; # 1 MB
                 };
               };
             });
             default = null;
           };
-          syslog = mkOption {
+          syslog = lib.mkOption {
             description = "Log via syslog, either to a UDS or over TCP/UDP.";
-            type = nullOr (submodule ({ config, ... }:
+            type = lib.types.nullOr (lib.types.submodule ({ config, ... }:
               let
                 cfg = config;
               in
@@ -42,35 +42,35 @@ let
                 options = {
                   type = lib.mkOption {
                     description = "Syslog type, UDS, TCP, or UDP.";
-                    type = enum [ "uds" "tcp" "udp" ];
+                    type = lib.types.enum [ "uds" "tcp" "udp" ];
                   };
                   dst = lib.mkOption {
                     description = "The endpoint to log to, format depends on the type.";
-                    type = str;
+                    type = lib.types.str;
                   };
                   time = lib.mkOption {
                     description = "Whether the complete sender timestamp should be included in log messages";
-                    type = bool;
+                    type = lib.types.bool;
                     default = false;
                   };
                   host = lib.mkOption {
                     description = "Whether the hostname should be included in log messages.";
-                    type = bool;
+                    type = lib.types.bool;
                     default = true;
                   };
                   timeQuality = lib.mkOption {
                     description = "Whether time quality information should be included in the log messages.";
-                    type = bool;
+                    type = lib.types.bool;
                     default = false;
                   };
                   tag = lib.mkOption {
                     description = "Every message will be marked with this tag.";
-                    type = nullOr str;
+                    type = with lib.types; nullOr str;
                     default = null;
                   };
                   priority = lib.mkOption {
                     description = "Mark every message with a priority.";
-                    type = nullOr str;
+                    type = with lib.types; nullOr str;
                     default = null;
                   };
                 };

--- a/modules/initrd/default.nix
+++ b/modules/initrd/default.nix
@@ -7,20 +7,19 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, nglib, ... }:
-with lib;
 let
   cfg = config.initrd;
 in
 {
   options.initrd = {
-    enable = mkEnableOption "Enable initrd as init";
+    enable = lib.mkEnableOption "Enable initrd as init";
   };
 
-  config.init = mkMerge [
+  config.init = lib.mkMerge [
     {
       availableInits = [ "initrd" ];
     }
-    (mkIf cfg.enable {
+    (lib.mkIf cfg.enable {
       type = "initrd";
       script = nglib.writeSubstitutedShellScript {
         name = "init";

--- a/modules/misc/iana.nix
+++ b/modules/misc/iana.nix
@@ -7,21 +7,20 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, nglib, ... }:
-with lib;
 let
   cfg = config.iana;
 in
 {
   options.iana = {
-    enable = mkOption {
+    enable = lib.mkOption {
       description = "Enable /etc/services creation.";
-      type = types.bool;
+      type = lib.types.bool;
       default = true;
     };
 
-    package = mkOption {
+    package = lib.mkOption {
       description = "iana package.";
-      type = types.package;
+      type = lib.types.package;
       default = pkgs.iana-etc;
     };
   };

--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -7,8 +7,28 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, nglib, ... }:
-with lib;
 let
+  inherit
+    (lib)
+    getVersion
+    versionAtLeast
+    isString
+    isInt
+    isBool
+    isList
+    concatMapStringsSep
+    concatStringsSep
+    mapAttrsToList
+    mkIf
+    mkDefault
+    optionals
+    mkMerge
+    range
+    mkOption
+    types
+    mkEnableOption
+    ;
+
   cfg = config.nix;
 
   nix = cfg.package.out;

--- a/modules/runit/default.nix
+++ b/modules/runit/default.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, nglib, ... }:
-with lib;
 let
   cfg = config.runit;
   cfgSystem = config.system;
@@ -15,27 +14,27 @@ let
 in
 {
   options.runit = {
-    enable = mkEnableOption "Enable runit";
+    enable = lib.mkEnableOption "Enable runit";
 
-    pkg = mkOption {
+    pkg = lib.mkOption {
       description = "runit package to use";
-      type = types.package;
+      type = lib.types.package;
       default = pkgs.runit;
     };
 
-    runtimeServiceDirectory = mkOption {
+    runtimeServiceDirectory = lib.mkOption {
       description = "where runsvdir should create superwise and log directories for services";
-      type = types.path;
+      type = lib.types.path;
       default = "/service";
     };
 
-    stages = mkOption {
+    stages = lib.mkOption {
       description = "runit stages";
       default = { };
-      type = types.submodule {
+      type = lib.types.submodule {
         options = {
-          stage-1 = mkOption {
-            type = types.path;
+          stage-1 = lib.mkOption {
+            type = lib.types.path;
             description = "runit stage 1";
             default = pkgs.writeSubstitutedShellScript {
               name = "runit-stage-1";
@@ -45,8 +44,8 @@ in
               };
             };
           };
-          stage-2 = mkOption {
-            type = types.path;
+          stage-2 = lib.mkOption {
+            type = lib.types.path;
             description = "runit stage 2";
             default = pkgs.writeSubstitutedShellScript {
               name = "runit-stage-2";
@@ -57,8 +56,8 @@ in
               };
             };
           };
-          stage-3 = mkOption {
-            type = types.path;
+          stage-3 = lib.mkOption {
+            type = lib.types.path;
             description = "runit stage 3";
             default = pkgs.writeSubstitutedShellScript {
               name = "runit-stage-3";
@@ -69,9 +68,9 @@ in
         };
       };
     };
-    serviceDirectory = mkOption {
+    serviceDirectory = lib.mkOption {
       description = "Generated service directory";
-      type = types.path;
+      type = lib.types.path;
       readOnly = true;
     };
   };
@@ -97,7 +96,7 @@ in
     runit = {
       serviceDirectory = pkgs.runCommandNoCC "service-dir" { } ''
         mkdir $out
-        ${concatStringsSep "\n" (mapAttrsToList (n: s:
+        ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: s:
           let
             run = pkgs.callPackage ./run.nix {} { inherit n s; };
             finish = pkgs.callPackage ./finish.nix {} { inherit n s cfgInit; };
@@ -108,17 +107,17 @@ in
               ln -s ${run} $out/${n}/run
               ln -s ${finish} $out/${n}/finish
               ln -s ${log} $out/${n}/log/run
-              ${optionalString (!s.enabled) "touch $out/${n}/down"}
+              ${lib.optionalString (!s.enabled) "touch $out/${n}/down"}
             ''
         ) cfgInit.services)}
       '';
     };
 
-    init = mkMerge [
+    init = lib.mkMerge [
       {
         availableInits = [ "runit" ];
       }
-      (mkIf cfg.enable {
+      (lib.mkIf cfg.enable {
         type = "runit";
         shutdown = pkgs.writeShellScript "runit-shutdown"
           ''

--- a/modules/runit/finish.nix
+++ b/modules/runit/finish.nix
@@ -13,7 +13,7 @@
 writeShellScript "${n}-finish" ''
   ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
-    optionalString (!cv.persistent) ''
+    lib.optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
         echo '${n}: removing non-presistent `${dst}`'
         rm -v ${dst}
@@ -23,7 +23,7 @@ writeShellScript "${n}-finish" ''
 
   ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
-    optionalString (!cv.persistent) ''
+    lib.optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
         echo '${n}: removing non-presistent `${dst}`'
         rm -rv ${dst}
@@ -37,7 +37,7 @@ writeShellScript "${n}-finish" ''
 
   ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
-    optionalString (!cv.persistent) ''
+    lib.optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
         echo '${n}: removing non-persistent `${dst}`'
         rm -rv '${dst}'
@@ -47,7 +47,7 @@ writeShellScript "${n}-finish" ''
 
   ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
-    optionalString (!cv.persistent) ''
+    lib.optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
         echo '${n}: removing non-persistent `${dst}`'
 

--- a/modules/runit/finish.nix
+++ b/modules/runit/finish.nix
@@ -10,9 +10,8 @@
 , writeShellScript
 }:
 { n, s, cfgInit }:
-with lib;
 writeShellScript "${n}-finish" ''
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
     optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
@@ -22,7 +21,7 @@ writeShellScript "${n}-finish" ''
     ''
   ) s.ensureSomething.link)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
     optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
@@ -32,11 +31,11 @@ writeShellScript "${n}-finish" ''
     ''
   ) s.ensureSomething.copy)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     abort "linkFarm is not implemented yet in runit!"
   ) s.ensureSomething.linkFarm)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
     optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
@@ -46,7 +45,7 @@ writeShellScript "${n}-finish" ''
     ''
   ) s.ensureSomething.exec)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
     optionalString (!cv.persistent) ''
       if [[ -e ${dst} ]] ; then
@@ -67,10 +66,10 @@ writeShellScript "${n}-finish" ''
 
   (
     cd ${s.pwd}
-    ${optionalString (s.environment != {}) "export ${concatStringsSep " " (mapAttrsToList (n: v: "${n}=${v}") s.environment)}"}
-    ${optionalString (s.finish != null && !s.shutdownOnExit) "exec ${s.finish}"}
-    ${optionalString (s.finish != null && s.shutdownOnExit) "${s.finish}"}
+    ${lib.optionalString (s.environment != {}) "export ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "${n}=${v}") s.environment)}"}
+    ${lib.optionalString (s.finish != null && !s.shutdownOnExit) "exec ${s.finish}"}
+    ${lib.optionalString (s.finish != null && s.shutdownOnExit) "${s.finish}"}
   )
 
-  ${optionalString (s.shutdownOnExit) ("exec ${cfgInit.shutdown}")}
+  ${lib.optionalString (s.shutdownOnExit) ("exec ${cfgInit.shutdown}")}
 ''

--- a/modules/runit/log.nix
+++ b/modules/runit/log.nix
@@ -11,7 +11,6 @@
 , writeShellScript
 }:
 { n, s }:
-with lib;
 writeShellScript "${n}-log" ''
   ${
     if s.log.file != null then

--- a/modules/runit/run.nix
+++ b/modules/runit/run.nix
@@ -10,9 +10,8 @@
 , writeShellScript
 }:
 { n, s }:
-with lib;
 writeShellScript "${n}-run" ''
-  ${concatStringsSep "\n" (map (dependency:
+  ${lib.concatStringsSep "\n" (map (dependency:
     ''
       if ! sv check "${dependency}" ; then
         exit -1
@@ -20,7 +19,7 @@ writeShellScript "${n}-run" ''
     ''
   ) s.dependencies)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
       ''
         if ! [[ -e ${dst} ]] ; then
@@ -31,7 +30,7 @@ writeShellScript "${n}-run" ''
       ''
   ) s.ensureSomething.link)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
     ''
       if ! [[ -e ${dst} ]] ; then
@@ -42,11 +41,11 @@ writeShellScript "${n}-run" ''
     ''
   ) s.ensureSomething.copy)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     abort "linkFarm is not implemented yet in runit!"
   ) s.ensureSomething.linkFarm)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
     ''
       if ! [[ -e ${dst} ]] ; then
@@ -62,7 +61,7 @@ writeShellScript "${n}-run" ''
     ''
   ) s.ensureSomething.exec)}
 
-  ${concatStringsSep "\n" (mapAttrsToList (cn: cv:
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (cn: cv:
     with cv;
     ''
       if ! [[ -e ${dst} ]] ; then
@@ -86,6 +85,6 @@ writeShellScript "${n}-run" ''
   ) s.ensureSomething.create)}
 
   cd ${s.pwd}
-  ${optionalString (s.environment != {}) "export ${concatStringsSep " " (mapAttrsToList (n: v: "${n}=${v}") s.environment)}"}
+  ${lib.optionalString (s.environment != {}) "export ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "${n}=${v}") s.environment)}"}
   exec ${s.script}
 ''

--- a/modules/runit/run.nix
+++ b/modules/runit/run.nix
@@ -79,7 +79,7 @@ writeShellScript "${n}-run" ''
          }
 
         chown ${owner} ${dst}
-        ${optionalString (mode != null) "chmod ${mode} ${dst}"}
+        ${lib.optionalString (mode != null) "chmod ${mode} ${dst}"}
       fi
     ''
   ) s.ensureSomething.create)}

--- a/modules/security/ca.nix
+++ b/modules/security/ca.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { config, lib, pkgs, nglib, ... }:
-with lib;
 let
   cfg = config.security.ca;
 
@@ -19,7 +18,7 @@ let
     {
       files =
         cfg.certificateFiles ++
-        [ (builtins.toFile "extra.crt" (concatStringsSep "\n" cfg.certificates)) ];
+        [ (builtins.toFile "extra.crt" (lib.concatStringsSep "\n" cfg.certificates)) ];
       preferLocalBuild = true;
     }
     ''
@@ -28,7 +27,7 @@ let
 in
 {
   options.security.ca = {
-    certificateFiles = mkOption {
+    certificateFiles = lib.mkOption {
       description = ''
         A list of files containing trusted root certificates in PEM
         format. These are concatenated to form
@@ -36,26 +35,26 @@ in
         used by many programs that use OpenSSL, such as
         <command>curl</command> and <command>git</command>.
       '';
-      type = with types; listOf path;
+      type = with lib.types; listOf path;
       default = [ ];
     };
 
-    certificates = mkOption {
+    certificates = lib.mkOption {
       description = ''
         A list of trusted root certificates in PEM format.
       '';
-      type = with types; listOf str;
+      type = with lib.types; listOf str;
       default = [ ];
     };
 
-    certificateBlacklist = mkOption {
+    certificateBlacklist = lib.mkOption {
       description = ''
         A list of blacklisted CA certificate names that won't be imported from
         the Mozilla Trust Store into
         <filename>/etc/ssl/certs/ca-certificates.crt</filename>. Use the
         names from that file.
       '';
-      type = with types; listOf str;
+      type = with lib.types; listOf str;
       default = [ ];
     };
   };

--- a/modules/services/apache2-nixos.nix
+++ b/modules/services/apache2-nixos.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, nglib, ... }:
-with lib;
 let
   cfg = config.services.apache2;
   runtimeConfig = "/run/cfg/apache.cfg";
@@ -17,24 +16,24 @@ in
 {
   options = {
     services.apache2 = {
-      enable = mkEnableOption "Enable Apache2 http server";
-      package = mkOption {
+      enable = lib.mkEnableOption "Enable Apache2 http server";
+      package = lib.mkOption {
         description = "Apache2 package";
-        type = types.package;
+        type = lib.types.package;
         default = pkgs.apacheHttpd;
       };
-      createUserGroup = mkOption {
+      createUserGroup = lib.mkOption {
         description = ''
           Whether to create the default user <literal>www-data</literal>
           and group <literal>www-data</literal>.
         '';
-        type = types.bool;
+        type = lib.types.bool;
         default = true;
       };
-      envsubst = mkEnableOption "Run envsubst on the configuration file.";
-      configuration = mkOption {
+      envsubst = lib.mkEnableOption "Run envsubst on the configuration file.";
+      configuration = lib.mkOption {
         description = "Apache2 configuration";
-        type = with types;
+        type = with lib.types;
           let
             self =
               oneOf [
@@ -53,7 +52,7 @@ in
   };
 
 
-  config = mkIf cfg.enable
+  config = lib.mkIf cfg.enable
     {
       init.services.apache2 =
         let
@@ -80,9 +79,9 @@ in
           enabled = true;
         };
 
-      environment.systemPackages = with pkgs; [ cfg.package ];
+      environment.systemPackages = [ cfg.package ];
 
-      users.users."www-data" = mkIf cfg.createUserGroup {
+      users.users."www-data" = lib.mkIf cfg.createUserGroup {
         description = "Apache HTTPD";
         group = "www-data";
         createHome = false;
@@ -91,7 +90,7 @@ in
         uid = config.ids.uids.www-data;
       };
 
-      users.groups."www-data" = mkIf cfg.createUserGroup {
+      users.groups."www-data" = lib.mkIf cfg.createUserGroup {
         gid = config.ids.gids.www-data;
       };
     };

--- a/modules/services/crond.nix
+++ b/modules/services/crond.nix
@@ -22,7 +22,7 @@ in
     crontabs = lib.mkOption {
       type = with lib.types; attrsOf (submodule {
         options = {
-          environment = mkOption {
+          environment = lib.mkOption {
             type = attrsOf str;
             description = ''
               A set of environment variable to set for this specific crontab.
@@ -34,7 +34,7 @@ in
             '';
             default = { };
           };
-          jobs = mkOption {
+          jobs = lib.mkOption {
             type = listOf str;
             description = ''
               A list of job entries, in the usual cron format.

--- a/modules/services/crond.nix
+++ b/modules/services/crond.nix
@@ -7,21 +7,20 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { config, nglib, lib, pkgs, ... }:
-with lib;
 let
   cfg = config.services.crond;
 in
 {
   options.services.crond = {
-    enable = mkEnableOption "Enable crond, the daemon to execute scheduled commands, specifically cronie.";
-    package = mkOption {
-      type = types.package;
+    enable = lib.mkEnableOption "Enable crond, the daemon to execute scheduled commands, specifically cronie.";
+    package = lib.mkOption {
+      type = lib.types.package;
       description = "The package which contains a cron implementation.";
       default = pkgs.cronie;
     };
 
-    crontabs = mkOption {
-      type = with types; attrsOf (submodule {
+    crontabs = lib.mkOption {
+      type = with lib.types; attrsOf (submodule {
         options = {
           environment = mkOption {
             type = attrsOf str;
@@ -69,16 +68,16 @@ in
       apply = x:
         let
           cronfiles =
-            (mapAttrsToList
+            (lib.mapAttrsToList
               (n: v: pkgs.writeText n
                 ''
-                  ${concatStringsSep "\n" (mapAttrsToList (n: v: ''"${n}"="${v}"'') v.environment)}
-                  ${concatStringsSep "\n" v.jobs}
+                  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: ''"${n}"="${v}"'') v.environment)}
+                  ${lib.concatStringsSep "\n" v.jobs}
                 '')
               x);
         in
         pkgs.runCommandNoCCLocal "cron.d" { } ''
-          CRONFILES="${concatStringsSep " " cronfiles}"
+          CRONFILES="${lib.concatStringsSep " " cronfiles}"
           mkdir -p $out
           for cronfile in $CRONFILES ; do
             ln -s "$cronfile" $out/$(basename "$cronfile")
@@ -87,7 +86,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     system.activation."crond" = nglib.dag.dagEntryAnywhere
       ''
         export PATH=${pkgs.busybox}/bin
@@ -104,6 +103,6 @@ in
         enabled = true;
       };
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
   };
 }

--- a/modules/services/dovecot.nix
+++ b/modules/services/dovecot.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, nglib, ... }:
-with lib;
 let
   cfg = config.services.dovecot;
 
@@ -22,48 +21,48 @@ in
 {
   options = {
     services.dovecot = {
-      enable = mkEnableOption "Enable Dovecot.";
+      enable = lib.mkEnableOption "Enable Dovecot.";
 
-      package = mkOption {
+      package = lib.mkOption {
         description = "Dovecot package.";
-        type = types.package;
+        type = lib.types.package;
         default = pkgs.dovecot;
       };
 
-      user = mkOption {
+      user = lib.mkOption {
         description = "Dovecot user.";
-        type = types.str;
+        type = lib.types.str;
         default = "dovecot";
       };
 
-      group = mkOption {
+      group = lib.mkOption {
         description = "Dovecot group.";
-        type = types.str;
+        type = lib.types.str;
         default = "dovecot";
       };
 
-      mailUser = mkOption {
+      mailUser = lib.mkOption {
         description = "Dovecot mail user.";
-        type = types.nullOr types.str;
+        type = lib.types.nullOr lib.types.str;
         default = "vmail";
       };
 
-      mailGroup = mkOption {
+      mailGroup = lib.mkOption {
         description = "Dovecot mail group.";
-        type = types.nullOr types.str;
+        type = with lib.types; nullOr str;
         default = "vmail";
       };
 
-      loginUser = mkOption {
+      loginUser = lib.mkOption {
         description = "Dovecot user for untrusted logins, should not have access to anything.";
-        type = types.nullOr types.str;
+        type = with lib.types; nullOr str;
         default = "dovenull";
       };
 
-      modules = mkOption {
-        type = types.listOf types.package;
+      modules = lib.mkOption {
+        type = with lib.types; listOf package;
         default = [ ];
-        example = literalExample "[ pkgs.dovecot_pigeonhole ]";
+        example = lib.literalExample "[ pkgs.dovecot_pigeonhole ]";
         description = ''
           Symlinks the contents of lib/dovecot of every given package into
           the haskell modules directory. This will make the given modules available
@@ -71,8 +70,8 @@ in
         '';
       };
 
-      config = mkOption {
-        type = with types;
+      config = lib.mkOption {
+        type = with lib.types;
           let
             self = attrsOf (nullOr (oneOf [
               str
@@ -89,8 +88,8 @@ in
         apply = x: pkgs.writeText "dovecot.conf" (nglib.generators.toDovecot x);
       };
 
-      extConfig = mkOption {
-        type = with types;
+      extConfig = lib.mkOption {
+        type = with lib.types;
           let
             self = attrsOf (nullOr (oneOf [
               str
@@ -104,47 +103,47 @@ in
           self // { description = "loop breaker"; };
         description = "Extra config files to generate, if you pass in a config attrset, you can access the generated file via the `config.services.dovecot.extConfig.<name>` attribute.";
         default = { };
-        apply = x: mapAttrs (n: v: pkgs.writeText n (nglib.generators.toDovecot v)) x;
+        apply = x: lib.mapAttrs (n: v: pkgs.writeText n (nglib.generators.toDovecot v)) x;
       };
     };
   };
 
-  config = mkIf cfg.enable
+  config = lib.mkIf cfg.enable
     {
-      users.users."dovecot" = mkIf (cfg.user == "dovecot") {
+      users.users."dovecot" = lib.mkIf (cfg.user == "dovecot") {
         uid = ids.uids.dovecot;
         description = "Dovecot user.";
         group = "dovecot";
       };
-      users.groups."dovecot" = mkIf (cfg.group == "dovecot") {
+      users.groups."dovecot" = lib.mkIf (cfg.group == "dovecot") {
         gid = ids.gids.dovecot;
       };
-      users.users."vmail" = mkIf (cfg.mailUser == "vmail") {
+      users.users."vmail" = lib.mkIf (cfg.mailUser == "vmail") {
         uid = ids.uids.vmail;
         description = "vmail user.";
         group = "vmail";
       };
-      users.groups."vmail" = mkIf (cfg.mailGroup == "vmail") {
+      users.groups."vmail" = lib.mkIf (cfg.mailGroup == "vmail") {
         gid = ids.gids.vmail;
       };
-      users.users."dovenull" = mkIf (cfg.loginUser == "dovenull") {
+      users.users."dovenull" = lib.mkIf (cfg.loginUser == "dovenull") {
         uid = ids.uids.dovenull;
         description = "Dovecot untrusted login user.";
         group = "dovenull";
       };
-      users.groups."dovenull" = mkIf (cfg.loginUser == "dovenull") {
+      users.groups."dovenull" = lib.mkIf (cfg.loginUser == "dovenull") {
         gid = ids.gids.dovenull;
       };
 
-      environment.systemPackages = with pkgs; [ cfg.package ];
+      environment.systemPackages = [ cfg.package ];
 
       services.dovecot = {
         config = {
-          default_login_user = mkIf (cfg.loginUser != null) cfg.loginUser;
-          default_internal_user = mkIf (cfg.user != null) cfg.user;
-          default_internal_group = mkIf (cfg.group != null) cfg.group;
+          default_login_user = lib.mkIf (cfg.loginUser != null) cfg.loginUser;
+          default_internal_user = lib.mkIf (cfg.user != null) cfg.user;
+          default_internal_group = lib.mkIf (cfg.group != null) cfg.group;
 
-          auth_mechanisms = mkDefault "plain";
+          auth_mechanisms = lib.mkDefault "plain";
 
           namespace."inbox" = {
             inbox = true;
@@ -174,13 +173,13 @@ in
 
       init.services.dovecot =
         {
-          ensureSomething.link."modules" = mkDefault {
+          ensureSomething.link."modules" = lib.mkDefault {
             src = modulesDir;
             dst = "/etc/dovecot/modules";
             persistent = false;
           };
 
-          ensureSomething.link."config" = mkDefault {
+          ensureSomething.link."config" = lib.mkDefault {
             src = cfg.config;
             dst = "/etc/dovecot/dovecot.conf";
             persistent = false;

--- a/modules/services/getty.nix
+++ b/modules/services/getty.nix
@@ -7,15 +7,14 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, ... }:
-with lib;
 let
   cfg = config.services.getty;
 
   optionsApplyFn = x:
-    if isString x then
+    if lib.isString x then
       x
-    else if isList x then
-      concatMapStringsSep " " optionsApplyFn x
+    else if lib.isList x then
+      lib.concatMapStringsSep " " optionsApplyFn x
     else
       toString x;
   optionsCreateArgument = k: v:
@@ -25,49 +24,49 @@ let
       ''"--${k}"'';
 in
 {
-  options.services.getty = mkOption {
+  options.services.getty = lib.mkOption {
     description = "All of the agettys";
-    type = types.attrsOf (types.submodule {
+    type = lib.types.attrsOf (lib.types.submodule {
       options = {
-        port = mkOption {
+        port = lib.mkOption {
           description = "TTY port.";
-          type = types.str;
+          type = lib.types.str;
         };
 
-        baudrate = mkOption {
+        baudrate = lib.mkOption {
           description = "TTY baud rate.";
-          type = with types;
+          type = with lib.types;
             nullOr (oneOf [ (listOf int) int str ]);
           default = null;
         };
 
-        term = mkOption {
+        term = lib.mkOption {
           description = "TTY terminal name.";
-          type = types.str;
+          type = lib.types.str;
           default = "vt220";
         };
 
-        options = mkOption {
+        options = lib.mkOption {
           description = "Extra options passed to the binary.";
-          type = with types;
+          type = with lib.types;
             let
               values = [ int str bool path (listOf (oneOf [ int str bool path ])) ];
             in
-              attrsOf (nullOr (oneOf values));
-          default = {};
+            attrsOf (nullOr (oneOf values));
+          default = { };
         };
 
-        package = mkOption {
+        package = lib.mkOption {
           description = "getty package.";
-          type = types.path;
+          type = lib.types.path;
           default = pkgs.util-linuxSystemdFree;
         };
       };
     });
     default = { };
   };
-  config.init.services =  mapAttrs'
-    (name: getty: nameValuePair "getty-${name}"
+  config.init.services = lib.mapAttrs'
+    (name: getty: lib.nameValuePair "getty-${name}"
       {
         script = with getty;
           pkgs.writeShellScript "getty-${name}-run"

--- a/modules/services/getty.nix
+++ b/modules/services/getty.nix
@@ -73,10 +73,10 @@ in
             ''
               exec ${package}/sbin/agetty \
                  "${port}" \
-                 ${concatStringsSep " " (mapAttrsToList optionsCreateArgument options)}
-                 "${optionalString
+                 ${lib.concatStringsSep " " (lib.mapAttrsToList optionsCreateArgument options)}
+                 "${lib.optionalString
                    (baudrate != null)
-                   (if isList baudrate then
+                   (if lib.isList baudrate then
                      concatMapStringsSep "," toString baudrate
                     else
                       toString baudrate)}" \

--- a/modules/services/gitea.nix
+++ b/modules/services/gitea.nix
@@ -7,69 +7,68 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, ... }:
-with lib;
 let
   cfg = config.services.gitea;
   ids = config.ids;
 
-  configFormat = pkgs.formats.ini {};
+  configFormat = pkgs.formats.ini { };
 
   defaultUser = "gitea";
 
   giteaSecrets = {
     options = {
-      secretKeyFile = mkOption {
+      secretKeyFile = lib.mkOption {
         description = ''
           Path to a file containing Gitea's secret key, on one line.
           If non-<literal>null</literal>, the contents of this file will
           substituted into the generated configuration file in-place of
           <literal>#secretKey#</literal>.
         '';
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         default = null;
       };
-      internalTokenFile = mkOption {
+      internalTokenFile = lib.mkOption {
         description = ''
           Path to a file containing Gitea's internal token, on one line.
           If non-<literal>null</literal>, the contents of this file will
           substituted into the generated configuration file in-place of
           <literal>#internalToken#</literal>.
         '';
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         default = null;
       };
-      jwtSecretFile = mkOption {
+      jwtSecretFile = lib.mkOption {
         description = ''
           Path to a file containing Gitea's JWT secret, on one line.
           If non-<literal>null</literal>, the contents of this file
           will substituted into the generated configuration file in-place
           of <literal>#jwtSecret#</literal>.
         '';
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         default = null;
       };
-      lfsJwtSecretFile = mkOption {
+      lfsJwtSecretFile = lib.mkOption {
         description = ''
           Path to a file containing Gitea's LFS JWT secret, on one line.
           If non-<literal>null</literal>, the contents of this file will
           substituted into the generated configuration file in-place of
           <literal>#lfsJwtSecret#</literal>.
         '';
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         default = null;
       };
 
-      databaseUserFile = mkOption {
+      databaseUserFile = lib.mkOption {
         description = ''
           Path to a file containing user with which Gitea should connect
           to it's database, on one line. If non-<literal>null</literal>,
           the contents of this file will substituted into the generated
           configuration file in-place of <literal>#databaseUser#</literal>.
         '';
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         default = null;
       };
-      databasePasswordFile = mkOption {
+      databasePasswordFile = lib.mkOption {
         description = ''
           Path to a file containing password with which Gitea should
           connect to it's database, on one line. If
@@ -77,43 +76,43 @@ let
           substituted into the generated configuration file in-place
           of <literal>#databasePassword#</literal>.
         '';
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         default = null;
       };
-      databaseHostFile = mkOption {
+      databaseHostFile = lib.mkOption {
         description = ''
           Path to a file containing database host to which Gitea should
           connect, on one line. If non-<literal>null</literal>, the
           contents of this file will substituted into the generated
           configuration file in-place of <literal>#databaseHost#</literal>.
         '';
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         default = null;
       };
     };
   };
 
-  secretModule = {name, ...}: {
+  secretModule = { name, ... }: {
     options = {
-      source = mkOption {
-        type = types.attrTag {
-          file = mkOption {
-            type = types.path;
+      source = lib.mkOption {
+        type = lib.types.attrTag {
+          file = lib.mkOption {
+            type = lib.types.path;
           };
 
-          environment = mkOption {
-            type = types.str;
+          environment = lib.mkOption {
+            type = lib.types.str;
           };
         };
       };
 
-      generate = mkOption {
-        type = types.str;
+      generate = lib.mkOption {
+        type = lib.types.str;
         default = "false";
       };
 
-      placeholder = mkOption {
-        type = types.str;
+      placeholder = lib.mkOption {
+        type = lib.types.str;
         default = name;
       };
     };
@@ -123,7 +122,7 @@ let
     attrs.${a};
 
   tagCase = a: attrs:
-    attrs.${head (attrNames a)};
+    attrs.${lib.head (lib.attrNames a)};
 
   fromMaybe = maybe: value:
     if maybe == null then
@@ -133,10 +132,10 @@ let
 
   declareSubstituteSecrets =
     secrets:
-    {
-      targetNotFound ? "_targetNotFound_default",
-      secretNotUsed ? "_secretNotUsed_default",
-      secretNotFound ? "_secretNotFound_default",
+    { targetNotFound ? "_targetNotFound_default"
+    , secretNotUsed ? "_secretNotUsed_default"
+    , secretNotFound ? "_secretNotFound_default"
+    ,
     }:
     ''
       function _targetNotFound_default() {
@@ -168,7 +167,7 @@ let
           ${targetNotFound} "$_target"
         fi
 
-        ${concatMapStringsSep "\n" (secret:
+        ${lib.concatMapStringsSep "\n" (secret:
           ''
             local _placeholder="${secret.placeholder}"
             grep "@$_placeholder@" "$_target" || ${secretNotUsed} "$_target" "$_placeholder"
@@ -193,34 +192,34 @@ let
 
             sed -i "s,@${secret.placeholder}@,$_secret,g" "$_target"
           ''
-        ) (attrValues secrets)}
+        ) (lib.attrValues secrets)}
       }
     '';
 in
 {
   imports = [
-    (mkRemovedOptionModule [ "services" "gitea" "appName" ] "The option has been moved to <services.gitea.settings.default.appName")
-    (mkRemovedOptionModule [ "services" "gitea" "runMode" ] "The option has been moved to <services.gitea.settings.default.runMode")
-    (mkRemovedOptionModule [ "services" "gitea" "user" ] "The option has been moved to <services.gitea.settings.default.runUser")
-    (mkRemovedOptionModule [ "services" "gitea" "configuration" ] "The option has been renamed to <services.gitea.settings>")
+    (lib.mkRemovedOptionModule [ "services" "gitea" "appName" ] "The option has been moved to <services.gitea.settings.default.appName")
+    (lib.mkRemovedOptionModule [ "services" "gitea" "runMode" ] "The option has been moved to <services.gitea.settings.default.runMode")
+    (lib.mkRemovedOptionModule [ "services" "gitea" "user" ] "The option has been moved to <services.gitea.settings.default.runUser")
+    (lib.mkRemovedOptionModule [ "services" "gitea" "configuration" ] "The option has been renamed to <services.gitea.settings>")
   ];
 
   options.services.gitea = {
-    enable = mkEnableOption "Enable Gitea service.";
+    enable = lib.mkEnableOption "Enable Gitea service.";
 
-    package = mkOption {
+    package = lib.mkOption {
       description = "Gitea package.";
-      type = types.package;
+      type = lib.types.package;
       default = pkgs.gitea;
     };
 
-    secrets = mkOption {
+    secrets = lib.mkOption {
       description = "Gitea secrets.";
-      type = types.attrsOf (types.submodule secretModule);
+      type = lib.types.attrsOf (lib.types.submodule secretModule);
       default = { };
     };
 
-    settings = mkOption {
+    settings = lib.mkOption {
       description = ''
         Gitea configuration.
       '';
@@ -233,17 +232,17 @@ in
       '';
     };
 
-    runConfig = mkOption {
+    runConfig = lib.mkOption {
       description = ''
         Path to Gitea's runtime generated configuration, with secrets.
       '';
-      type = types.path;
+      type = lib.types.path;
       default = "/var/run/gitea/app.ini";
     };
     # add explicit path settings and ensure them, also add to config but only as defaults
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.gitea.settings = {
       server.STATIC_ROOT_PATH = "${cfg.package.data}";
     };
@@ -270,26 +269,26 @@ in
           let
             appIni = configFormat.generate "app.ini" cfg.settings;
           in
-            ''
-              set -x
-              export PATH=${pkgs.busybox}/bin:${pkgs.bash}/bin
+          ''
+            set -x
+            export PATH=${pkgs.busybox}/bin:${pkgs.bash}/bin
 
-              cp ${appIni} ${cfg.runConfig}
-              chmod 600 ${cfg.runConfig}
-              chown ${cfg.settings.default.RUN_USER}:nogroup ${cfg.runConfig}
+            cp ${appIni} ${cfg.runConfig}
+            chmod 600 ${cfg.runConfig}
+            chown ${cfg.settings.default.RUN_USER}:nogroup ${cfg.runConfig}
 
-              ${declareSubstituteSecrets cfg.secrets { secretNotFound = "false"; }}
-              substituteSecrets ${cfg.runConfig}
-              cat ${cfg.runConfig}
+            ${declareSubstituteSecrets cfg.secrets { secretNotFound = "false"; }}
+            substituteSecrets ${cfg.runConfig}
+            cat ${cfg.runConfig}
 
-              ${optionalString (cfg.package.name == pkgs.forgejo.name) ''
-                mkdir -p ${cfg.settings.server.APP_DATA_PATH}/conf
-                ln -sf ${cfg.package}/locasle ${cfg.settings.server.APP_DATA_PATH}/conf
-              ''}
+            ${lib.optionalString (cfg.package.name == pkgs.forgejo.name) ''
+              mkdir -p ${cfg.settings.server.APP_DATA_PATH}/conf
+              ln -sf ${cfg.package}/locasle ${cfg.settings.server.APP_DATA_PATH}/conf
+            ''}
 
-              export HOME=${cfg.settings.server.APP_DATA_PATH}
-              chpst -u ${cfg.settings.default.RUN_USER or "root"}:nogroup ${cfg.package}/bin/gitea -c ${cfg.runConfig}
-            ''
+            export HOME=${cfg.settings.server.APP_DATA_PATH}
+            chpst -u ${cfg.settings.default.RUN_USER or "root"}:nogroup ${cfg.package}/bin/gitea -c ${cfg.runConfig}
+          ''
         );
 
       enabled = true;
@@ -297,7 +296,7 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    users.users."gitea" = mkIf ((cfg.settings.default.RUN_USER or "root") == defaultUser) {
+    users.users."gitea" = lib.mkIf ((cfg.settings.default.RUN_USER or "root") == defaultUser) {
       uid = ids.uids.gitea;
       description = "Gitea user";
     };

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -64,7 +64,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    services.home-assistant.config = lib.mkDefaultRec
+    services.home-assistant.config = nglib.mkDefaultRec
       {
         http.server_port = "8123";
       };

--- a/modules/services/hydra.nix
+++ b/modules/services/hydra.nix
@@ -452,7 +452,7 @@ in
           environment = env;
           pwd = baseDir;
           script = pkgs.writeShellScript "hydra-evaluator" ''
-            export PATH=${with pkgs; makeBinPath [ hydra-package nettools jq ]}:$PATH
+            export PATH=${with pkgs; lib.makeBinPath [ hydra-package nettools jq ]}:$PATH
 
             sv -v -w 0 once hydra-init
             [[ ! -e ${baseDir}/.init-hydra ]] && exit 1

--- a/modules/services/jmusicbot.nix
+++ b/modules/services/jmusicbot.nix
@@ -7,26 +7,25 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, ... }:
-with lib;
 let
   cfg = config.services.jmusicbot;
 in
 {
   options.services.jmusicbot = {
-    enable = mkEnableOption "Enable JMusicBot";
+    enable = lib.mkEnableOption "Enable JMusicBot";
 
-    package = mkOption {
+    package = lib.mkOption {
       description = "JMusicBot package to use.";
       default = pkgs.jmusicbot;
-      type = types.package;
+      type = lib.types.package;
     };
 
-    config = mkOption {
+    config = lib.mkOption {
       description = ''
         JMusicBot configuration file in Nix form. <link>https://github.com/jagrosh/MusicBot/wiki/Example-Config</link>
         This configuration file will be ran through envsubst, therefore "''${ENV_VAR}" works as you'd expect.
       '';
-      example = literalExample ''
+      example = lib.literalExample ''
         {
           token = "BOT_TOKEN";
           owner = 1254789614;
@@ -37,51 +36,51 @@ in
           };
         }
       '';
-      type = with types; attrsOf (oneOf [ str int bool (attrsOf (listOf str)) ]);
+      type = with lib.types; attrsOf (oneOf [ str int bool (attrsOf (listOf str)) ]);
       apply = x:
         pkgs.writeText "jmusicbot-config.txt"
-          (concatMapStringsSep "\n"
+          (lib.concatMapStringsSep "\n"
             (
               { name, value }:
-              if isString value then
+              if lib.isString value then
                 "${name} = \"${value}\""
-              else if isInt value then
+              else if lib.isInt value then
                 "${name} = ${toString value}"
-              else if isBool value then
+              else if lib.isBool value then
                 if value then
                   "${name} = true"
                 else
                   "${name} = false"
-              else if isAttrs value then
+              else if lib.isAttrs value then
                 "${name} {"
                 +
-                concatMapStringsSep "\n" (
+                lib.concatMapStringsSep "\n" (
                   { name, value }:
-                  "${name} = [ ${concatStringsSep ", " value} ]"
+                  "${name} = [ ${lib.concatStringsSep ", " value} ]"
                 )
                 +
                 "}"
               else
                 throw "Type error"
             )
-            (mapAttrsToList nameValuePair x));
+            (lib.mapAttrsToList lib.nameValuePair x));
     };
 
-    user = mkOption {
+    user = lib.mkOption {
       description = "User to run JMusicBot under.";
       default = "jmusicbot";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    group = mkOption {
+    group = lib.mkOption {
       description = "Group to run JMusicBot under.";
       default = "jmusicbot";
-      type = types.str;
+      type = lib.types.str;
     };
   };
 
-  config = mkIf cfg.enable {
-    users.users.${cfg.user} = mapAttrs (_: mkDefault) {
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = lib.mapAttrs (_: lib.mkDefault) {
       description = "JMusicBot";
       group = cfg.group;
       home = "/var/empty";
@@ -91,10 +90,10 @@ in
     };
 
     users.groups.${cfg.group} = {
-      gid = mkDefault config.ids.gids.jmusicbot;
+      gid = lib.mkDefault config.ids.gids.jmusicbot;
     };
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
 
     init.services.jmusicbot =
       {

--- a/modules/services/mosquitto.nix
+++ b/modules/services/mosquitto.nix
@@ -7,86 +7,91 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, nglib, ... }:
-with nglib; with lib;
 let
   cfg = config.services.mosquitto;
 
   format =
-    { type = with types;
+    {
+      type = with lib.types;
         let self = attrsOf (oneOf [ str path bool int (listOf (oneOf [ str path bool int self ])) ]);
         in self // { description = "attrs of str, path, bool, int or attrs of self"; };
       generate = config:
         pkgs.writeTextFile
-          { name = "mosquitto.conf";
-            text = let
-              self = config:
-                mapAttrsToList
-                  (n: v:
-                    if isString v || isInt v then
-                      "${n} ${toString v}\n"
-                    else if isBool v then
-                      "${n} ${if v then "true" else "false"}\n"
-                    else if isList v then
-                      if length v != 2 then
-                        throw "Invalid subtree list length of ${length v}"
-                      else if (isString (elemAt v 0) || isInt (elemAt v 0)) && isAttrs (elemAt v 1) then
-                        "${n} ${toString (elemAt v 0)}\n${concatStringsSep " " (self (elemAt v 1))}"
-                      else if (isBool (elemAt v 0)) && isAttrs (elemAt v 1) then
-                        "${n} ${if elemAt v 0 then "true" else "false"}\n${concatStringsSep " " (self (elemAt v 1))}"
+          {
+            name = "mosquitto.conf";
+            text =
+              let
+                self = config:
+                  lib.mapAttrsToList
+                    (n: v:
+                      if lib.isString v || lib.isInt v then
+                        "${n} ${toString v}\n"
+                      else if lib.isBool v then
+                        "${n} ${if v then "true" else "false"}\n"
+                      else if lib.isList v then
+                        if lib.length v != 2 then
+                          throw "Invalid subtree list length of ${lib.length v}"
+                        else if (lib.isString (lib.elemAt v 0) || lib.isInt (lib.elemAt v 0)) && lib.isAttrs (lib.elemAt v 1) then
+                          "${n} ${toString (lib.elemAt v 0)}\n${lib.concatStringsSep " " (self (lib.elemAt v 1))}"
+                        else if (lib.isBool (lib.elemAt v 0)) && lib.isAttrs (lib.elemAt v 1) then
+                          "${n} ${if lib.elemAt v 0 then "true" else "false"}\n${lib.concatStringsSep " " (self (lib.elemAt v 1))}"
+                        else
+                          throw "Invalid subtree content"
                       else
-                        throw "Invalid subtree content"
-                    else
-                      throw "unreachable"
-                  )
-                  config;
-              in self config;
+                        throw "unreachable"
+                    )
+                    config;
+              in
+              self config;
           };
     };
 in
 {
   options.services.mosquitto = {
-    enable = mkEnableOption "Enable Mosquitto MQTT broker.";
+    enable = lib.mkEnableOption "Enable Mosquitto MQTT broker.";
 
-    package = mkOption {
-      type =  with types; package;
+    package = lib.mkOption {
+      type = lib.types.package;
       default = pkgs.mosquitto;
       description = ''
         Which mosquitto package to use.
       '';
     };
 
-    config = mkOption {
+    config = lib.mkOption {
       type = format.type;
-      default = {};
+      default = { };
       description = ''
         Mosquitto configuration, <link>https://mosquitto.org/man/mosquitto-conf-5.html</link>.
       '';
     };
 
-    user = mkOption {
+    user = lib.mkOption {
       description = "mosquitto user.";
-      type = types.str;
+      type = lib.types.str;
       default = "mosquitto";
     };
 
-    group = mkOption {
+    group = lib.mkOption {
       description = "mosquitto group.";
-      type = types.str;
+      type = lib.types.str;
       default = "mosquitto";
     };
 
-    envsubst = mkEnableOption "Run envsubst on the configuration file.";
+    envsubst = lib.mkEnableOption "Run envsubst on the configuration file.";
   };
 
-  config = mkIf cfg.enable {
-    services.mosquitto.config = mkDefaultRec
+  config = lib.mkIf cfg.enable {
+    services.mosquitto.config = nglib.mkDefaultRec
       {
         persistence = true;
         persistence_location = "/var/mosquitto";
         listener =
-          ["1883 0.0.0.0"
-           ({ allow_anonymous = true;
-           })
+          [
+            "1883 0.0.0.0"
+            ({
+              allow_anonymous = true;
+            })
           ];
       };
 
@@ -95,7 +100,7 @@ in
         ''
           mkdir -p /var/mosquitto/ /run/mosquitto
           cp ${format.generate cfg.config} /run/mosquitto/configuration.yaml
-          ${optionalString cfg.envsubst
+          ${lib.optionalString cfg.envsubst
             ''
               rm /run/mosquitto/configuration.yaml
               ${pkgs.envsubst}/bin/envsubst \
@@ -112,9 +117,9 @@ in
       enabled = true;
     };
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
 
-    users.users.${cfg.user} = mkDefaultRec {
+    users.users.${cfg.user} = nglib.mkDefaultRec {
       description = "mosquitto";
       group = cfg.group;
       createHome = false;
@@ -123,7 +128,7 @@ in
       uid = config.ids.uids.mosquitto;
     };
 
-    users.groups.${cfg.group} = mkDefaultRec {
+    users.groups.${cfg.group} = nglib.mkDefaultRec {
       gid = config.ids.gids.mosquitto;
     };
   };

--- a/modules/services/nginx.nix
+++ b/modules/services/nginx.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, nglib, ... }:
-with nglib; with lib;
 let
   cfg = config.services.nginx;
   runtimeConfig = "/run/cfg/nginx.cfg";
@@ -17,26 +16,26 @@ in
 {
   options = {
     services.nginx = {
-      enable = mkEnableOption "Enable Nginx http server.";
-      package = mkOption {
+      enable = lib.mkEnableOption "Enable Nginx http server.";
+      package = lib.mkOption {
         description = "Nginx package.";
-        type = types.package;
+        type = lib.types.package;
         default = pkgs.nginx;
       };
-      user = mkOption {
+      user = lib.mkOption {
         description = "Nginx user.";
-        type = types.str;
+        type = lib.types.str;
         default = "nginx";
       };
-      group = mkOption {
+      group = lib.mkOption {
         description = "Nginx group.";
-        type = types.str;
+        type = lib.types.str;
         default = "nginx";
       };
-      envsubst = mkEnableOption "Run envsubst on the configuration file.";
-      configuration = mkOption {
+      envsubst = lib.mkEnableOption "Run envsubst on the configuration file.";
+      configuration = lib.mkOption {
         description = "Nginx configuration";
-        type = with types;
+        type = with lib.types;
           let
             self =
               oneOf [
@@ -54,7 +53,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable
+  config = lib.mkIf cfg.enable
     {
       init.services.nginx =
         let
@@ -88,9 +87,9 @@ in
           enabled = true;
         };
 
-      environment.systemPackages = with pkgs; [ cfg.package ];
+      environment.systemPackages = [ cfg.package ];
 
-      users.users.${cfg.user} = mkDefaultRec {
+      users.users.${cfg.user} = nglib.mkDefaultRec {
         description = "Nginx";
         group = cfg.group;
         createHome = false;
@@ -99,7 +98,7 @@ in
         uid = config.ids.uids.nginx;
       };
 
-      users.groups.${cfg.group} = mkDefaultRec {
+      users.groups.${cfg.group} = nglib.mkDefaultRec {
         gid = config.ids.gids.nginx;
       };
     };

--- a/modules/services/pantalaimon.nix
+++ b/modules/services/pantalaimon.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, ... }:
-with lib;
 let
   cfg = config.services.pantalaimon;
 
@@ -15,19 +14,19 @@ let
 in
 {
   options.services.pantalaimon = {
-    enable = mkEnableOption "Enable pantalaimon";
+    enable = lib.mkEnableOption "Enable pantalaimon";
 
-    package = mkOption {
+    package = lib.mkOption {
       description = "Pantalaimon package to use";
       default = pkgs.pantalaimon.override { enableDbusUi = false; };
-      type = types.package;
+      type = lib.types.package;
     };
 
-    config = mkOption {
+    config = lib.mkOption {
       description = ''
         Pantalaimon configuration file in Nix form. <link>https://github.com/matrix-org/pantalaimon/blob/master/docs/man/pantalaimon.5.md</link>.
       '';
-      example = literalExample ''
+      example = lib.literalExample ''
         {
           Default =
             {
@@ -46,25 +45,25 @@ in
             };
         }
       '';
-      type = with types; attrsOf (attrsOf (oneOf [ string int ]));
+      type = with lib.types; attrsOf (attrsOf (oneOf [ string int ]));
       apply = x: with pkgs; writeText "pantalaimon.conf" (generators.toINI { } x);
     };
 
-    user = mkOption {
+    user = lib.mkOption {
       description = "User to run Pantalaimon under.";
       default = "pantalaimon";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    group = mkOption {
+    group = lib.mkOption {
       description = "Group to run Pantalaimon under.";
       default = "pantalaimon";
-      type = types.str;
+      type = lib.types.str;
     };
   };
 
-  config = mkIf cfg.enable {
-    users.users.${cfg.user} = mapAttrs (_: mkDefault) {
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = lib.mapAttrs (_: lib.mkDefault) {
       description = "Pantalaimon";
       group = cfg.group;
       home = "/var/empty";
@@ -73,10 +72,10 @@ in
     };
 
     users.groups.${cfg.group} = {
-      gid = mkDefault config.ids.gids.pantalaimon;
+      gid = lib.mkDefault config.ids.gids.pantalaimon;
     };
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
 
     init.services.pantalaimon =
       {

--- a/modules/services/pantalaimon.nix
+++ b/modules/services/pantalaimon.nix
@@ -46,7 +46,7 @@ in
         }
       '';
       type = with lib.types; attrsOf (attrsOf (oneOf [ string int ]));
-      apply = x: with pkgs; writeText "pantalaimon.conf" (generators.toINI { } x);
+      apply = x: with pkgs; writeText "pantalaimon.conf" (lib.generators.toINI { } x);
     };
 
     user = lib.mkOption {

--- a/modules/services/postfix.nix
+++ b/modules/services/postfix.nix
@@ -7,13 +7,12 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, nglib, ... }:
-with lib;
 let
   cfg = config.services.postfix;
   inherit (config.users) createDefaultUsersGroups;
 
-  yes-no-nothing = types.enum [ "y" "n" "-" ];
-  masterCfModule = with types; submodule {
+  yes-no-nothing = lib.types.enum [ "y" "n" "-" ];
+  masterCfModule = with lib.types; submodule {
     options = {
       type = mkOption {
         type = types.enum [ "inet" "unix" "unix-dgram" "fifo" "pass" ];
@@ -123,35 +122,35 @@ in
 {
   options = {
     services.postfix = {
-      enable = mkEnableOption "Enable Postfix MTA.";
+      enable = lib.mkEnableOption "Enable Postfix MTA.";
 
-      package = mkOption {
+      package = lib.mkOption {
         description = "Postfix package.";
-        type = types.package;
+        type = lib.types.package;
         default = pkgs.postfix;
       };
 
-      user = mkOption {
+      user = lib.mkOption {
         description = "Postfix user.";
-        type = types.str;
+        type = lib.types.str;
         default = "postfix";
       };
 
-      group = mkOption {
+      group = lib.mkOption {
         description = "Postfix group.";
-        type = types.str;
+        type = lib.types.str;
         default = "postfix";
       };
 
-      setgidGroup = mkOption {
+      setgidGroup = lib.mkOption {
         description = "Postfix privilege drop group.";
-        type = types.str;
+        type = lib.types.str;
         default = "postdrop";
       };
 
-      mainConfig = mkOption {
+      mainConfig = lib.mkOption {
         description = "Postfix main.cnf.";
-        type = with types;
+        type = with lib.types;
           attrsOf (nullOr (oneOf [
             str
             int
@@ -162,21 +161,21 @@ in
         default = { };
       };
 
-      masterConfig = mkOption {
+      masterConfig = lib.mkOption {
         description = "Postfix master.cfg.";
-        type = with types;
+        type = with lib.types;
           attrsOf (nullOr (either masterCfModule (listOf masterCfModule)));
         default = { };
         apply = x:
-          concatStringsSep "\n" (mapAttrsToList
+          lib.concatStringsSep "\n" (lib.mapAttrsToList
             (n: v:
               if isNull v then
                 ""
-              else if isAttrs v then
+              else if lib.isAttrs v then
                 with v;
                 "${n} ${type} ${private} ${unpriv} ${chroot} ${wakeup} ${maxproc} ${command}"
               else
-                concatMapStringsSep "\n"
+                lib.concatMapStringsSep "\n"
                   (y:
                     with y;
                     "${n} ${type} ${private} ${unpriv} ${chroot} ${wakeup} ${maxproc} ${command}"
@@ -188,9 +187,9 @@ in
     };
   };
 
-  config = mkIf cfg.enable
+  config = lib.mkIf cfg.enable
     {
-      users.users.${cfg.user} = mkDefault {
+      users.users.${cfg.user} = lib.mkDefault {
         description = "Postfix";
         group = cfg.group;
         createHome = false;
@@ -200,42 +199,42 @@ in
       };
 
       users.groups.${cfg.group} = {
-        gid = mkDefault config.ids.gids.postfix;
+        gid = lib.mkDefault config.ids.gids.postfix;
       };
 
       users.groups.${cfg.setgidGroup} = {
-        gid = mkDefault config.ids.gids.postdrop;
+        gid = lib.mkDefault config.ids.gids.postdrop;
       };
 
-      environment.systemPackages = with pkgs; [ cfg.package ];
+      environment.systemPackages = [ cfg.package ];
 
       services.postfix = {
         mainConfig = {
-          compatibility_level = mkDefault cfg.package.version;
-          mail_owner = mkDefault cfg.user;
-          default_privs = mkDefault "nobody";
+          compatibility_level = lib.mkDefault cfg.package.version;
+          mail_owner = lib.mkDefault cfg.user;
+          default_privs = lib.mkDefault "nobody";
 
           # NixOS specific locations
-          data_directory = mkDefault "/var/lib/postfix/data";
-          queue_directory = mkDefault "/var/lib/postfix/queue";
+          data_directory = lib.mkDefault "/var/lib/postfix/data";
+          queue_directory = lib.mkDefault "/var/lib/postfix/queue";
 
           # Default location of everything in package
           meta_directory = "${cfg.package}/etc/postfix";
           command_directory = "${cfg.package}/bin";
-          sample_directory = mkDefault "/etc/postfix";
+          sample_directory = lib.mkDefault "/etc/postfix";
           newaliases_path = "${cfg.package}/bin/newaliases";
           mailq_path = "${cfg.package}/bin/mailq";
-          readme_directory = mkDefault false;
+          readme_directory = lib.mkDefault false;
           sendmail_path = "${cfg.package}/bin/sendmail";
           daemon_directory = "${cfg.package}/libexec/postfix";
           manpage_directory = "${cfg.package}/share/man";
           html_directory = "${cfg.package}/share/postfix/doc/html";
-          shlib_directory = mkDefault false;
-          mail_spool_directory = mkDefault "/var/spool/mail/";
-          setgid_group = mkDefault cfg.setgidGroup;
+          shlib_directory = lib.mkDefault false;
+          mail_spool_directory = lib.mkDefault "/var/spool/mail/";
+          setgid_group = lib.mkDefault cfg.setgidGroup;
         };
 
-        masterConfig = mapAttrs (_: v: mkDefault v) {
+        masterConfig = lib.mapAttrs (_: v: lib.mkDefault v) {
           pickup = {
             type = "unix";
             private = "n";
@@ -322,7 +321,7 @@ in
             '';
         in
         {
-          ensureSomething.create."data" = mkDefault {
+          ensureSomething.create."data" = lib.mkDefault {
             type = "directory";
             mode = "750";
             owner = "${cfg.user}:${cfg.group}";
@@ -330,7 +329,7 @@ in
             persistent = true;
           };
 
-          ensureSomething.create."queue" = mkDefault {
+          ensureSomething.create."queue" = lib.mkDefault {
             type = "directory";
             mode = "750";
             owner = "${cfg.user}:root";

--- a/modules/services/postfix.nix
+++ b/modules/services/postfix.nix
@@ -14,13 +14,13 @@ let
   yes-no-nothing = lib.types.enum [ "y" "n" "-" ];
   masterCfModule = with lib.types; submodule {
     options = {
-      type = mkOption {
+      type = lib.mkOption {
         type = types.enum [ "inet" "unix" "unix-dgram" "fifo" "pass" ];
         description = ''
           Service type.
         '';
       };
-      private = mkOption {
+      private = lib.mkOption {
         type = yes-no-nothing;
         description = ''
           Whether or not access is restricted to the mail system.   Inter-
@@ -28,7 +28,7 @@ let
         '';
         default = "-";
       };
-      unpriv = mkOption {
+      unpriv = lib.mkOption {
         type = yes-no-nothing;
         description = ''
           Whether the service runs with root privileges or as the owner of
@@ -40,7 +40,7 @@ let
         '';
         default = "-";
       };
-      chroot = mkOption {
+      chroot = lib.mkOption {
         type = yes-no-nothing;
         description = ''
           Whether or not the service  runs  chrooted  to  the  mail  queue
@@ -59,7 +59,7 @@ let
         '';
         default = "-";
       };
-      wakeup = mkOption {
+      wakeup = lib.mkOption {
         type = types.oneOf [ int str ];
         description = ''
           Automatically wake up the named service after the specified num-
@@ -74,12 +74,12 @@ let
         '';
         default = "-";
         apply = x:
-          if isString x then
+          if lib.isString x then
             x
           else
             toString x;
       };
-      maxproc = mkOption {
+      maxproc = lib.mkOption {
         type = types.oneOf [ int str ];
         description = ''
           The maximum number of processes that may  execute  this  service
@@ -92,13 +92,13 @@ let
         '';
         default = "-";
         apply = x:
-          if isString x then
+          if lib.isString x then
             x
           else
             toString x;
       };
-      command = mkOption {
-        type = types.str;
+      command = lib.mkOption {
+        type = lib.types.str;
         description = ''
           The command to be executed.  Characters that are special to  the
           shell  such  as  ">"  or  "|"  have no special meaning here, and

--- a/modules/services/postgresql.nix
+++ b/modules/services/postgresql.nix
@@ -11,7 +11,6 @@
 #   Copyright (c) 2003-2021 Eelco Dolstra and the Nixpkgs/NixOS contributors
 
 { pkgs, lib, config, ... }:
-with lib;
 let
   cfg = config.services.postgresql;
 
@@ -19,27 +18,27 @@ let
   toStr = value:
     if true == value then "yes"
     else if false == value then "no"
-    else if isString value then "'${lib.replaceStrings ["'"] ["''"] value}'"
+    else if lib.isString value then "'${lib.replaceStrings ["'"] ["''"] value}'"
     else toString value;
 
-  configFile = pkgs.writeTextDir "postgresql.conf" (concatStringsSep "\n" (mapAttrsToList (n: v: "${n} = ${toStr v}") cfg.config));
+  configFile = pkgs.writeTextDir "postgresql.conf" (lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") cfg.config));
 in
 {
   options = {
     services.postgresql = {
 
-      enable = mkEnableOption "PostgreSQL Server";
+      enable = lib.mkEnableOption "PostgreSQL Server";
 
-      package = mkOption {
-        type = types.package;
-        example = literalExample "pkgs.postgresql_11";
+      package = lib.mkOption {
+        type = lib.types.package;
+        example = lib.literalExample "pkgs.postgresql_11";
         description = ''
           PostgreSQL package to use.
         '';
       };
 
-      port = mkOption {
-        type = types.int;
+      port = lib.mkOption {
+        type = lib.types.int;
         default = 5432;
         description = ''
           The port on which PostgreSQL listens.
@@ -47,14 +46,14 @@ in
         apply = toString;
       };
 
-      checkConfig = mkOption {
-        type = types.bool;
+      checkConfig = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = "Check the syntax of the configuration file at compile time";
       };
 
-      dataDir = mkOption {
-        type = types.path;
+      dataDir = lib.mkOption {
+        type = lib.types.path;
         defaultText = "/var/lib/postgresql/\${config.services.postgresql.package.psqlSchema}";
         example = "/var/lib/postgresql/11";
         description = ''
@@ -65,8 +64,8 @@ in
         '';
       };
 
-      authentication = mkOption {
-        type = types.lines;
+      authentication = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = ''
           Defines how users authenticate themselves to the server. See the
@@ -82,8 +81,8 @@ in
         '';
       };
 
-      identMap = mkOption {
-        type = types.lines;
+      identMap = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = ''
           Defines the mapping from system users to database users.
@@ -92,8 +91,8 @@ in
         '';
       };
 
-      initdbArgs = mkOption {
-        type = with types; listOf str;
+      initdbArgs = lib.mkOption {
+        type = with lib.types; listOf str;
         default = [ ];
         example = [ "--data-checksums" "--allow-group-access" ];
         description = ''
@@ -102,16 +101,16 @@ in
         '';
       };
 
-      initialScript = mkOption {
-        type = with types; nullOr (oneOf [ package str ]);
+      initialScript = lib.mkOption {
+        type = with lib.types; nullOr (oneOf [ package str ]);
         default = null;
         description = ''
           A file containing SQL statements to execute on first startup.
         '';
       };
 
-      ensureExtensions = mkOption {
-        type = with types; attrsOf (listOf str);
+      ensureExtensions = lib.mkOption {
+        type = with lib.types; attrsOf (listOf str);
         default = { };
         description = ''
           Ensure that the specified extensions exist.
@@ -121,8 +120,8 @@ in
         };
       };
 
-      ensureDatabases = mkOption {
-        type = with types;
+      ensureDatabases = lib.mkOption {
+        type = with lib.types;
           oneOf [ (listOf str) (attrsOf (attrsOf str)) ];
         default = [ ];
         description = ''
@@ -131,7 +130,7 @@ in
           option is changed. This means that databases created once through this option or
           otherwise have to be removed manually.
         '';
-        example = literalExample ''
+        example = lib.literalExample ''
           [
             "gitea" = { encoding = UTF-8; }
             "hydra"
@@ -139,17 +138,17 @@ in
         '';
       };
 
-      ensureUsers = mkOption {
-        type = types.listOf (types.submodule {
+      ensureUsers = lib.mkOption {
+        type = with lib.types; listOf (submodule {
           options = {
             name = mkOption {
-              type = types.str;
+              type = str;
               description = ''
                 Name of the user to ensure.
               '';
             };
-            ensurePermissions = mkOption {
-              type = types.attrsOf types.str;
+            ensurePermissions = lib.mkOption {
+              type = attrsOf str;
               default = { };
               description = ''
                 Permissions to ensure for the user, specified as an attribute set.
@@ -161,17 +160,17 @@ in
                 <link xlink:href="https://www.postgresql.org/docs/current/sql-grant.html">GRANT syntax</link>.
                 The attributes are used as <code>GRANT ''${attrName} ON ''${attrValue}</code>.
               '';
-              example = literalExample ''
+              example = lib.literalExample ''
                 {
                   "DATABASE \"nextcloud\"" = "ALL PRIVILEGES";
                   "ALL TABLES IN SCHEMA public" = "ALL PRIVILEGES";
                 }
               '';
             };
-            ensureDBOwnership = mkOption {
-              type = types.bool;
+            ensureDBOwnership = lib.mkOption {
+              type = bool;
               default = false;
-              description = mdDoc ''
+              description = lib.mdDoc ''
                 Grants the  user ownership to a database with the same name.
                 This database must be defined manually in
                 [](#opt-services.postgresql.ensureDatabases).
@@ -188,7 +187,7 @@ in
           option is changed. This means that users created and permissions assigned once through this option or
           otherwise have to be removed manually.
         '';
-        example = literalExample ''
+        example = lib.literalExample ''
           [
             {
               name = "nextcloud";
@@ -206,8 +205,8 @@ in
         '';
       };
 
-      enableTCPIP = mkOption {
-        type = types.bool;
+      enableTCPIP = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether PostgreSQL should listen on all network interfaces.
@@ -216,8 +215,8 @@ in
         '';
       };
 
-      logLinePrefix = mkOption {
-        type = types.str;
+      logLinePrefix = lib.mkOption {
+        type = lib.types.str;
         default = "Postgres [%p] ";
         example = "%m [%p] ";
         description = ''
@@ -227,18 +226,18 @@ in
         '';
       };
 
-      extraPlugins = mkOption {
-        type = types.listOf types.path;
+      extraPlugins = lib.mkOption {
+        type = with lib.types; listOf path;
         default = [ ];
-        example = literalExample "with pkgs.postgresql_11.pkgs; [ postgis pg_repack ]";
+        example = lib.literalExample "with pkgs.postgresql_11.pkgs; [ postgis pg_repack ]";
         description = ''
           List of PostgreSQL plugins. PostgreSQL version for each plugin should
           match version for <literal>services.postgresql.package</literal> value.
         '';
       };
 
-      config = mkOption {
-        type = with types; attrsOf (oneOf [ bool float int str ]);
+      config = lib.mkOption {
+        type = with lib.types; attrsOf (oneOf [ bool float int str ]);
         default = { };
         description = ''
           PostgreSQL configuration. Refer to
@@ -249,7 +248,7 @@ in
             escaped with two single quotes as described by the upstream documentation linked above.
           </para></note>
         '';
-        example = literalExample ''
+        example = lib.literalExample ''
           {
             log_connections = true;
             log_statement = "all";
@@ -260,16 +259,16 @@ in
         '';
       };
 
-      recoveryConfig = mkOption {
-        type = types.nullOr types.lines;
+      recoveryConfig = lib.mkOption {
+        type = with lib.types; nullOr lines;
         default = null;
         description = ''
           Contents of the <filename>recovery.conf</filename> file.
         '';
       };
 
-      superUser = mkOption {
-        type = types.str;
+      superUser = lib.mkOption {
+        type = lib.types.str;
         default = "postgres";
         internal = true;
         readOnly = true;
@@ -282,8 +281,8 @@ in
   };
   # END Copyright (c) 2003-2021 Eelco Dolstra and the Nixpkgs/NixOS contributors
 
-  config = mkIf cfg.enable {
-    environment.systemPackages = with pkgs; [ cfg.package ];
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
 
     # BEGIN Copyright (c) 2003-2021 Eelco Dolstra and the Nixpkgs/NixOS contributors
     services.postgresql.config = {
@@ -295,9 +294,9 @@ in
       port = cfg.port;
     };
 
-    services.postgresql.dataDir = mkDefault "/var/lib/postgresql/${cfg.package.psqlSchema}";
+    services.postgresql.dataDir = lib.mkDefault "/var/lib/postgresql/${cfg.package.psqlSchema}";
 
-    services.postgresql.authentication = mkAfter
+    services.postgresql.authentication = lib.mkAfter
       ''
         # Generated file; do not edit!
         local all all              peer
@@ -361,13 +360,13 @@ in
            rm -f ${cfg.dataDir}/*.conf
 
            # Initialize the database
-           chpst -u postgres:postgres ${cfg.package}/bin/initdb -U ${cfg.superUser} ${concatStringsSep " " cfg.initdbArgs}
+           chpst -u postgres:postgres ${cfg.package}/bin/initdb -U ${cfg.superUser} ${lib.concatStringsSep " " cfg.initdbArgs}
 
            touch ${cfg.dataDir}/.first_startup
         fi
 
         ln -sfn ${configFile}/postgresql.conf ${cfg.dataDir}/postgresql.conf
-        ${optionalString (cfg.recoveryConfig != null) ''
+        ${lib.optionalString (cfg.recoveryConfig != null) ''
           ln -sfn "${pkgs.writeText "recovery.conf" cfg.recoveryConfig}" \
           "${cfg.dataDir}/recovery.conf"
         ''}
@@ -381,25 +380,25 @@ in
           sleep 0.1
         done
 
-        ${concatMapStrings ({ database, options }: ''
+        ${lib.concatMapStrings ({ database, options }: ''
           $PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = '${database}'" | grep -q 1 || $PSQL -tAc 'CREATE DATABASE "${database}" ${if options != "" then "WITH " + options else ""}'
         '')
-          ((if isList cfg.ensureDatabases then
+          ((if lib.isList cfg.ensureDatabases then
             map (x: { database = x; options = ""; })
            else
-             mapAttrsToList (k: v: { database = k; options = concatStringsSep " " (mapAttrsToList (k: v: "${k} = \"${v}\"") v); }))
+             lib.mapAttrsToList (k: v: { database = k; options = lib.concatStringsSep " " (lib.mapAttrsToList (k: v: "${k} = \"${v}\"") v); }))
           cfg.ensureDatabases)}
 
-        ${concatMapStrings (user: ''
+        ${lib.concatMapStrings (user: ''
           $PSQL -tAc "SELECT 1 FROM pg_roles WHERE rolname='${user.name}'" | grep -q 1 || $PSQL -tAc 'CREATE USER "${user.name}"'
-          ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
+          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (database: permission: ''
             $PSQL -tAc 'GRANT ${permission} ON ${database} TO "${user.name}"'
           '') user.ensurePermissions)}
-          ${optionalString user.ensureDBOwnership ''$PSQL -tAc 'ALTER DATABASE "${user.name}" OWNER TO "${user.name}";' ''}
+          ${lib.optionalString user.ensureDBOwnership ''$PSQL -tAc 'ALTER DATABASE "${user.name}" OWNER TO "${user.name}";' ''}
         '') cfg.ensureUsers}
 
-        ${concatStrings (mapAttrsToList (extension: schemas:
-          concatMapStrings (schema:
+        ${lib.concatStrings (lib.mapAttrsToList (extension: schemas:
+          lib.concatMapStrings (schema:
             ''
               $PSQL -tAc "create extension if not exists ${extension}" ${schema}
             ''
@@ -407,7 +406,7 @@ in
         ) cfg.ensureExtensions)}
 
         if test -e "${cfg.dataDir}/.first_startup"; then
-          ${optionalString (cfg.initialScript != null) ''
+          ${lib.optionalString (cfg.initialScript != null) ''
             $PSQL -f "${cfg.initialScript}" -d postgres
           ''}
           rm -f "${cfg.dataDir}/.first_startup"

--- a/modules/services/postgresql.nix
+++ b/modules/services/postgresql.nix
@@ -141,7 +141,7 @@ in
       ensureUsers = lib.mkOption {
         type = with lib.types; listOf (submodule {
           options = {
-            name = mkOption {
+            name = lib.mkOption {
               type = str;
               description = ''
                 Name of the user to ensure.

--- a/modules/services/socklog.nix
+++ b/modules/services/socklog.nix
@@ -7,28 +7,27 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { config, lib, pkgs, ... }:
-with lib;
 let
   cfg = config.services.socklog;
 in
 {
   options.services.socklog = {
-    enable = mkEnableOption "Enable socklog.";
+    enable = lib.mkEnableOption "Enable socklog.";
 
-    package = mkOption {
+    package = lib.mkOption {
       description = "Socklog package.";
-      type = types.package;
+      type = lib.types.package;
       default = pkgs.socklog;
     };
 
-    unix = mkOption {
+    unix = lib.mkOption {
       description = "Make socklog listen on a unix domain socket. Input the path to the UDS socklog should use.";
-      type = with types; nullOr path;
+      type = with lib.types; nullOr path;
       default = null;
     };
-    inet = mkOption {
+    inet = lib.mkOption {
       description = "Make socklog listen on UDP.";
-      type = with types; nullOr (submodule {
+      type = with lib.types; nullOr (submodule {
         options = {
           ip = mkOption {
             description = ''
@@ -48,13 +47,13 @@ in
       default = null;
     };
   };
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     init.services.socklog =
       let
         unixSocklog =
-          optionalString (cfg.unix != null) "socklog unix ${cfg.unix} &";
+          lib.optionalString (cfg.unix != null) "socklog unix ${cfg.unix} &";
         inetSocklog =
-          optionalString (cfg.inet != null) "socklog inter ${cfg.inet.ip} ${toString cfg.inet.port} &";
+          lib.optionalString (cfg.inet != null) "socklog inter ${cfg.inet.ip} ${toString cfg.inet.port} &";
       in
       {
         script = pkgs.writeShellScript "socklog-run" ''
@@ -70,7 +69,7 @@ in
         enabled = true;
       };
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
 
     assertions = [
       {

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -7,7 +7,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, nglib, ... }:
-with nglib; with lib;
 let
   cfg = config.services.syncthing;
 
@@ -15,43 +14,43 @@ let
 in
 {
   options.services.syncthing = {
-    enable = mkEnableOption "Enable SyncThing";
+    enable = lib.mkEnableOption "Enable SyncThing";
 
-    package = mkOption {
+    package = lib.mkOption {
       description = "syncthing package to use.";
       default = pkgs.syncthing;
-      type = types.package;
+      type = lib.types.package;
     };
 
-    config = mkOption {
+    config = lib.mkOption {
       description = ''
         Configuration options for syncthing.
       '';
-      type = format.type;
-      default = {};
+      type = lib.format.type;
+      default = { };
     };
 
-    user = mkOption {
+    user = lib.mkOption {
       description = "Syncthing user.";
-      type = types.str;
+      type = lib.types.str;
       default = "syncthing";
     };
 
-    group = mkOption {
+    group = lib.mkOption {
       description = "Syncthing group.";
-      type = types.str;
+      type = lib.types.str;
       default = "syncthing";
     };
 
-    guiAddress = mkOption {
+    guiAddress = lib.mkOption {
       description = "Syncthing GUI address";
-      type = types.str;
+      type = lib.types.str;
       default = "http://127.0.0.1:8384/";
     };
   };
 
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     init.services.syncthing = {
       enabled = true;
       script = pkgs.writeShellScript "syncthing-run"
@@ -71,9 +70,9 @@ in
         '';
     };
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
 
-    users.users.${cfg.user} = mkDefaultRec {
+    users.users.${cfg.user} = lib.mkDefaultRec {
       description = "Syncthing";
       group = cfg.group;
       createHome = false;
@@ -82,8 +81,8 @@ in
       uid = config.ids.uids.syncthing;
     };
 
-    users.groups.${cfg.group} = mkDefaultRec {
+    users.groups.${cfg.group} = lib.mkDefaultRec {
       gid = config.ids.gids.syncthing;
     };
-  }; 
+  };
 }

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -72,7 +72,7 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    users.users.${cfg.user} = lib.mkDefaultRec {
+    users.users.${cfg.user} = nglib.mkDefaultRec {
       description = "Syncthing";
       group = cfg.group;
       createHome = false;
@@ -81,7 +81,7 @@ in
       uid = config.ids.uids.syncthing;
     };
 
-    users.groups.${cfg.group} = lib.mkDefaultRec {
+    users.groups.${cfg.group} = nglib.mkDefaultRec {
       gid = config.ids.gids.syncthing;
     };
   };

--- a/modules/services/zigbee2mqtt.nix
+++ b/modules/services/zigbee2mqtt.nix
@@ -7,12 +7,11 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, config, lib, nglib, ... }:
-with nglib; with lib;
 let
   cfg = config.services.zigbee2mqtt;
-  format = pkgs.formats.yaml {};
+  format = pkgs.formats.yaml { };
 
-  configDir = pkgs.runCommandNoCC "zigbee2mqtt-config-dir" {}
+  configDir = pkgs.runCommandNoCC "zigbee2mqtt-config-dir" { }
     ''
       mkdir -p $out
       ln -s ${format.generate "configuration.yaml" cfg.config} $out/configuration.yaml
@@ -20,41 +19,41 @@ let
 in
 {
   options.services.zigbee2mqtt = {
-    enable = mkEnableOption "Enable zigbee2mqtt.";
+    enable = lib.mkEnableOption "Enable zigbee2mqtt.";
 
-    package = mkOption {
-      type =  with types; package;
+    package = lib.mkOption {
+      type = lib.types.package;
       default = pkgs.zigbee2mqtt;
       description = ''
         Which zigbee2mqtt package to use.
       '';
     };
 
-    config = mkOption {
+    config = lib.mkOption {
       type = format.type;
-      default = {};
+      default = { };
       description = ''
         Home Assistant configuration, <link>https://www.home-assistant.io/docs/configuration/</link>.
       '';
     };
 
-    user = mkOption {
+    user = lib.mkOption {
       description = "zigbee2mqtt user.";
-      type = types.str;
+      type = lib.types.str;
       default = "zigbee2mqtt";
     };
 
-    group = mkOption {
+    group = lib.mkOption {
       description = "zigbee2mqtt group.";
-      type = types.str;
+      type = lib.types.str;
       default = "zigbee2mqtt";
     };
 
-    envsubst = mkEnableOption "Run envsubst on the configuration file.";
+    envsubst = lib.mkEnableOption "Run envsubst on the configuration file.";
   };
 
-  config = mkIf cfg.enable {
-    services.zigbee2mqtt.config = mkDefaultRec
+  config = lib.mkIf cfg.enable {
+    services.zigbee2mqtt.config = lib.mkDefaultRec
       {
         http.server_port = "8123";
       };
@@ -64,7 +63,7 @@ in
         ''
           mkdir -p /var/zigbee2mqtt/
           cp '${configDir}'/* /var/zigbee2mqtt/
-          ${optionalString cfg.envsubst
+          ${lib.optionalString cfg.envsubst
             ''
               rm /var/zigbee2mqtt/configuration.yaml
               ${pkgs.envsubst}/bin/envsubst \
@@ -81,9 +80,9 @@ in
       enabled = true;
     };
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
 
-    users.users.${cfg.user} = mkDefaultRec {
+    users.users.${cfg.user} = nglib.mkDefaultRec {
       description = "zigbee2mqtt";
       group = cfg.group;
       createHome = false;
@@ -92,7 +91,7 @@ in
       uid = config.ids.uids.zigbee2mqtt;
     };
 
-    users.groups.${cfg.group} = mkDefaultRec {
+    users.groups.${cfg.group} = nglib.mkDefaultRec {
       gid = config.ids.gids.zigbee2mqtt;
     };
   };

--- a/modules/services/zigbee2mqtt.nix
+++ b/modules/services/zigbee2mqtt.nix
@@ -53,7 +53,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    services.zigbee2mqtt.config = lib.mkDefaultRec
+    services.zigbee2mqtt.config = nglib.mkDefaultRec
       {
         http.server_port = "8123";
       };

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -7,8 +7,21 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, nglib, config, ... }:
-with lib; with nglib;
 let
+  inherit
+    (lib)
+    concatSepStrings
+    mkOption
+    types
+    mkEnableOption
+    ;
+
+  inherit
+    (nglib)
+    mergeShellFragmentsIsolated
+    mkDagOption
+    ;
+
   cfg = config.system;
 in
 {
@@ -94,7 +107,7 @@ in
         message = ''
           `cfg.activation` has one or more cycles and/or loops.
           - cycles:
-            ${(map (x: "{ after = [ ${concatSepStrings " " x.after} ]; data = ${x.data}; name = ${x.name} }") cfg.activation.loops or []) or ""}
+            ${(map (x: "{ after = [ ${concatSepStrings " " x.after} ]; data = ${x.data}; name = ${x.name} }") cfg.activation.loops or [])}
           - loops:
             ${(map (x: "{ after = [ ${concatSepStrings " " x.after} ]; data = ${x.data}; name = ${x.name} }") cfg.activation.loops or [])}
         '';

--- a/modules/system/bundle.nix
+++ b/modules/system/bundle.nix
@@ -7,11 +7,11 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, ... }:
-with lib;
 let
-  inherit (pkgs)
-    runCommandNoCC
-    writeReferencesToFile;
+  inherit (lib)
+    mkOption
+    types
+    ;
 in
 {
   options.system.build = {
@@ -24,11 +24,11 @@ in
   };
 
   config.system.build.bundle =
-    runCommandNoCC (config.system.name + "-bundle")
+    pkgs.runCommandNoCC (config.system.name + "-bundle")
       { }
       ''
         set -o pipefail
         mkdir -p $out
-        xargs tar c < ${writeReferencesToFile config.system.build.toplevel} | tar -xC $out/
+        xargs tar c < ${pkgs.writeReferencesToFile config.system.build.toplevel} | tar -xC $out/
       '';
 }

--- a/modules/system/initrd.nix
+++ b/modules/system/initrd.nix
@@ -7,35 +7,30 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, ... }:
-with lib;
 let
-  inherit (pkgs)
-    writeReferencesToFile
-    runCommandNoCC;
-
   bundleWithInit =
-    runCommandNoCC (config.system.name + "-bundle-with-init")
+    pkgs.runCommandNoCC (config.system.name + "-bundle-with-init")
       { }
       ''
         set -o pipefail
         mkdir -p $out
         ln -s ${config.system.build.toplevel}/init $out/init
-        xargs tar c < ${writeReferencesToFile config.system.build.toplevel} | tar -xC $out
+        xargs tar c < ${pkgs.writeReferencesToFile config.system.build.toplevel} | tar -xC $out
       '';
 
 in
 {
   options.system.build = {
-    initrd = mkOption {
+    initrd = lib.mkOption {
       description = ''
         Full system bundle packaged as a bootable initrd in cpio format.
       '';
-      type = types.path;
+      type = lib.types.path;
     };
   };
 
   config.system.build.initrd =
-    runCommandNoCC (config.system.name + "-initrd")
+    pkgs.runCommandNoCC (config.system.name + "-initrd")
       {
         nativeBuildInputs = with pkgs; [
           findutils

--- a/modules/system/oci-image.nix
+++ b/modules/system/oci-image.nix
@@ -7,8 +7,13 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, ... }:
-with lib;
 let
+  inherit
+    (lib)
+    mkOption
+    types
+    ;
+
   cfg = config.system;
 in
 {

--- a/modules/system/run.nix
+++ b/modules/system/run.nix
@@ -7,14 +7,13 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, ... }:
-with lib;
 {
   options.system.build = {
-    runDocker = mkOption {
+    runDocker = lib.mkOption {
       description = ''
           A script which will run the system in docker using nix store bind mounts.
         '';
-      type = types.path;
+      type = lib.types.path;
     };
   };
 

--- a/modules/system/toplevel.nix
+++ b/modules/system/toplevel.nix
@@ -7,39 +7,37 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { pkgs, lib, config, ... }:
-with lib;
 {
   options.system.build = {
-    toplevel = mkOption {
+    toplevel = lib.mkOption {
       description = ''
           The full system, built up.
         '';
-      type = types.path;
+      type = lib.types.path;
     };
   };
 
   config.system.build.toplevel =
     pkgs.runCommandNoCC "nixng-${config.system.name}"
       { nativeBuildInputs = with pkgs; [ busybox makeWrapper ]; }
-      (with config;
-        let
-          closureInfo = pkgs.closureInfo
-            { rootPaths = [ config.init.script system.activationScript ]; };
-        in
-          ''
-            mkdir $out
+      (let
+         closureInfo = pkgs.closureInfo
+          { rootPaths = [ config.init.script config.system.activationScript ]; };
+       in
+         ''
+           mkdir $out
 
-            # Substitute in the path to the system closure to avoid
-            # an infinite dep cycle
-            substitute ${init.script} $out/init \
-              --subst-var-by "systemConfig" "$out"
-            substitute ${system.activationScript} $out/activation \
-              --subst-var-by "systemConfig" "$out"
-            chmod +x $out/init $out/activation
-            echo "${pkgs.stdenv.system}" > $out/system
+           # Substitute in the path to the system closure to avoid
+           # an infinite dep cycle
+           substitute ${config.init.script} $out/init \
+             --subst-var-by "systemConfig" "$out"
+           substitute ${config.system.activationScript} $out/activation \
+             --subst-var-by "systemConfig" "$out"
+           chmod +x $out/init $out/activation
+           echo "${pkgs.stdenv.system}" > $out/system
 
-            #
-            ${optionalString system.createNixRegistration
-              "ln -s ${closureInfo}/registration $out/registration"}
-          '');
+           #
+           ${lib.optionalString config.system.createNixRegistration
+             "ln -s ${closureInfo}/registration $out/registration"}
+         '');
 }

--- a/modules/users.nix
+++ b/modules/users.nix
@@ -7,8 +7,23 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 { nglib, lib, pkgs, config, ... }:
-with lib;
 let
+  inherit
+    (lib)
+    mkIf
+    mkDefault
+    mkOption
+    types
+    concatMapStringsSep
+    filter
+    mapAttrsToList
+    mkMerge
+    optionalAttrs
+    flatten
+    singleton
+    concatStringsSep
+    ;
+
   ids = config.ids;
   cfg = config.users;
 


### PR DESCRIPTION
Not sure if 
```nix
{ lib, ... }:
let
  inherit
    (lib)
    map
    isString
    ;
in
  map isString [ "foo" 5 ]
```
or
```nix
{ lib, ... }:
lib.map lib.isString [ "foo" 5 ]
```
is preferred, opinions are welcome.