### PR TITLE
Don't validate Attic config

### DIFF
--- a/modules/services/attic.nix
+++ b/modules/services/attic.nix
@@ -3,20 +3,6 @@ let
   cfg = config.services.attic;
   atticd = lib.getExe cfg.package;
   settingsFormat = pkgs.formats.toml { };
-
-  validatedConfigFile = pkgs.stdenvNoCC.mkDerivation {
-    name = "attic-validated.toml";
-    src = cfg.configFile;
-    dontUnpack = true;
-
-    # Even the check-config mode needs a (dummy) secret.
-    ATTIC_SERVER_TOKEN_HS256_SECRET_BASE64 = "kONlkVtBeH1PPoc7jLo0X3xKnNzuLhwYf030ghOTCH817P6jzqotxuhzRSrlOxS/VAmb5UEDobgw21EFGk8+XA==";
-
-    buildPhase = ''
-      ${atticd} --mode check-config --config $src
-      cp $src $out
-    '';
-  };
 in
 {
   options.services.attic = {
@@ -85,7 +71,7 @@ in
           export ATTIC_SERVER_TOKEN_HS256_SECRET_BASE64="$(<'${cfg.credentialsFile}')"
         fi
 
-        chpst -b atticd ${atticd} --config ${validatedConfigFile}
+        chpst -b atticd ${atticd} --config ${cfg.configFile}
       '';
     };
 


### PR DESCRIPTION
Unfortunately `check-config` expects more than just the secret token for validation: it pretty much expect a whole working setup including a database. So this is not useful to do at build-time at all. I also found out Attic checks config at run-time anyways, so we can should validating at all.