### PR TITLE
Don't set /etc/shadow to immutable if rootless Docker is detected

### DIFF
--- a/modules/users.nix
+++ b/modules/users.nix
@@ -241,7 +241,13 @@ in
         chown 0:0 /etc/shadow
         chmod 400 /etc/shadow
         ${cfg.generateShadow} > /etc/shadow
-        chattr +i /etc/shadow
+
+        # Detect rootless Docker, which prevents setting files' immutable flag
+        mapped_root_uid=$(awk '$1 == 0 {print $2}' /proc/self/uid_map)
+        if [[ "$mapped_root_uid" -eq 0 ]]; then
+          chattr +i /etc/shadow
+        fi
+
         ${createHomes}
       '';
 


### PR DESCRIPTION
This checks if the root UID is mapped to anything

fixes #34 