### PR TITLE
Add Jellyseerr service

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -31,6 +31,7 @@ let
     "dnsmasq" = ./dnsmasq;
     "attic" = ./attic;
     "ntfy-sh" = ./ntfy-sh;
+    "jellyseerr" = ./jellyseerr;
   };
 in
 nixpkgs.lib.mapAttrs (_: v: import v { inherit nixpkgs nglib nixng; }) examples

--- a/examples/jellyseerr/default.nix
+++ b/examples/jellyseerr/default.nix
@@ -9,6 +9,10 @@ nglib.makeSystem {
     {
       dinit.enable = true;
       init.services.jellyseerr.shutdownOnExit = true;
-      services.jellyseerr.enable = true;
+
+      services.jellyseerr = {
+        enable = true;
+        port = 8080;
+      };
     };
 }

--- a/examples/jellyseerr/default.nix
+++ b/examples/jellyseerr/default.nix
@@ -1,0 +1,14 @@
+{ nglib, nixpkgs, ... }:
+nglib.makeSystem {
+  inherit nixpkgs;
+  system = "x86_64-linux";
+  name = "nixng-jellyseerr";
+
+  config =
+    { ... }:
+    {
+      dinit.enable = true;
+      init.services.jellyseerr.shutdownOnExit = true;
+      services.jellyseerr.enable = true;
+    };
+}

--- a/modules/list.nix
+++ b/modules/list.nix
@@ -50,4 +50,5 @@
   ./services/dnsmasq.nix
   ./services/attic.nix
   ./services/ntfy-sh.nix
+  ./services/jellyseerr.nix
 ]

--- a/modules/services/jellyseerr.nix
+++ b/modules/services/jellyseerr.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.jellyseerr;
+in
+{
+  options.services.jellyseerr = {
+    enable = lib.mkEnableOption "jellyseerr";
+    package = lib.mkPackageOption pkgs "jellyseerr" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    init.services.jellyseerr = {
+      enabled = true;
+      workingDirectory = "${cfg.package}/libexec/jellyseerr/deps/jellyseerr";
+
+      # TODO: simplify?
+      script = pkgs.writeShellScript "jellyseerr-run.sh" ''
+        ${lib.getExe cfg.package}
+      '';
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/modules/services/jellyseerr.nix
+++ b/modules/services/jellyseerr.nix
@@ -34,7 +34,6 @@ in
   config = lib.mkIf cfg.enable {
     init.services.jellyseerr = {
       enabled = true;
-      workingDirectory = "${cfg.package}/libexec/jellyseerr/deps/jellyseerr";
       script = lib.getExe cfg.package;
     };
 

--- a/modules/services/jellyseerr.nix
+++ b/modules/services/jellyseerr.nix
@@ -20,6 +20,15 @@ in
       example = 8080;
       default = 5055;
     };
+
+    configDir = lib.mkOption {
+      description = ''
+        The directory to save run-time configuration.
+      '';
+      type = lib.types.str;
+      example = "/jellyseerr";
+      default = "/var/lib/jellyseerr";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -31,7 +40,10 @@ in
 
     environment = {
       systemPackages = [ cfg.package ];
-      variables.PORT = builtins.toString cfg.port;
+      variables = {
+        PORT = builtins.toString cfg.port;
+        CONFIG_DIRECTORY = cfg.configDir;
+      };
     };
   };
 }

--- a/modules/services/jellyseerr.nix
+++ b/modules/services/jellyseerr.nix
@@ -11,19 +11,27 @@ in
   options.services.jellyseerr = {
     enable = lib.mkEnableOption "jellyseerr";
     package = lib.mkPackageOption pkgs "jellyseerr" { };
+
+    port = lib.mkOption {
+      description = ''
+        The port Jellyseerr should listen on.
+      '';
+      type = lib.types.port;
+      example = 8080;
+      default = 5055;
+    };
   };
 
   config = lib.mkIf cfg.enable {
     init.services.jellyseerr = {
       enabled = true;
       workingDirectory = "${cfg.package}/libexec/jellyseerr/deps/jellyseerr";
-
-      # TODO: simplify?
-      script = pkgs.writeShellScript "jellyseerr-run.sh" ''
-        ${lib.getExe cfg.package}
-      '';
+      script = lib.getExe cfg.package;
     };
 
-    environment.systemPackages = [ cfg.package ];
+    environment = {
+      systemPackages = [ cfg.package ];
+      variables.PORT = builtins.toString cfg.port;
+    };
   };
 }


### PR DESCRIPTION
Unsure how to improve the user experience on this one. Jellyseerr tries to write run-time config to `${cfg.package}/libexec/jellyseerr/deps/jellyseerr/config/` NixOS has solved this by [bind-mounting that directory](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/misc/jellyseerr.nix#L37C46-L37C101) to `/var/lib/jellyseerr`. In the container world this should obviously be a mounted volume, but without reading the source code it would be hard for a user to find out about where to mount. Also if the package is updated this location would change.