### PR TITLE
Slightly change `services.nginx.configuration` to allow for merging

### DIFF
--- a/modules/services/nginx.nix
+++ b/modules/services/nginx.nix
@@ -44,8 +44,22 @@ in
         type =
           with lib.types;
           let
-            self =
-              (listOf (oneOf [
+            optionalListOf =
+              elemType:
+              let
+                list = (types.listOf elemType);
+              in
+              list
+              // {
+                merge =
+                  loc: defs:
+                  list.merge loc (
+                    map (def: if lib.isList def.value then def else def // { value = lib.singleton def.value; }) defs
+                  );
+                check = lib.const true;
+              };
+            self = (
+              optionalListOf (oneOf [
                 str
                 (attrsOf (oneOf [
                   str
@@ -60,7 +74,8 @@ in
                   ]))
                   (attrsOf self)
                 ]))
-              ]));
+              ])
+            );
           in
           self // { description = "loop breaker"; };
       };

--- a/modules/services/nginx.nix
+++ b/modules/services/nginx.nix
@@ -44,25 +44,23 @@ in
         type =
           with lib.types;
           let
-            self = oneOf [
-              (attrsOf (oneOf [
+            self =
+              (listOf (oneOf [
                 str
-                int
-                (listOf (oneOf [
+                (attrsOf (oneOf [
                   str
                   int
                   (listOf (oneOf [
                     str
                     int
+                    (listOf (oneOf [
+                      str
+                      int
+                    ]))
                   ]))
+                  (attrsOf self)
                 ]))
-                (attrsOf self)
-              ]))
-              (listOf (oneOf [
-                str
-                self
-              ]))
-            ];
+              ]));
           in
           self // { description = "loop breaker"; };
       };


### PR DESCRIPTION
This might break someone's config an is untested, but without it, the following won't work:
```nix
[
  {
    services.nginx.configuration = [
      {
        http."" = {
          ...
        };
      }
    ];
  }
  {
    services..nginx.configuration = [
      {
        stream."" = {
          ...
        };
      }
    ];
  }
]
```

currently that'll fail with
```
error: The option `services.nginx.configuration' is defined multiple times while it's expected to be unique.
```
which is less than ideal for composability.

EDIT: this will break everything, 100% and also introduces infrecs in its current form