### PR TITLE
add `init.services.<name>.type`

### DIFF
--- a/modules/dinit/default.nix
+++ b/modules/dinit/default.nix
@@ -43,7 +43,7 @@ let
       rulesFile = pkgs.writeText "${name}.tmpfiles" (nglib.nottmpfiles.generate rules);
     in
     pkgs.writeText "${name}-service" ''
-      type = process
+      type = ${service.type}
       pid-file = /service/${name}/pid
 
       command = ${pkgs.writeShellScript "${name}-start.sh" ''

--- a/modules/init.nix
+++ b/modules/init.nix
@@ -260,6 +260,18 @@ in
             (lib.mkRenamedOptionModule [ "pwd" ] [ "workingDirectory" ])
           ];
           options = {
+            type = lib.mkOption {
+              description = ''
+                The type of service, the types are modelled after the service types
+                described in dinit-service(5).
+              '';
+              default = "process";
+              type = lib.types.enum [
+                "process"
+                "scripted"
+              ];
+            };
+
             dependencies = lib.mkOption {
               description = "Service dependencies";
               type = with lib.types; listOf str;

--- a/modules/runit/run.nix
+++ b/modules/runit/run.nix
@@ -97,5 +97,15 @@ writeShellScript "${n}-run" ''
   ${lib.optionalString (s.environment != { })
     "export ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "${n}=${v}") s.environment)}"
   }
-  exec ${nglib.maybeChangeUserAndGroup s.user s.group s.supplementaryGroups s.execStart}
+  ${
+    {
+      "process" = "exec ${
+        nglib.maybeChangeUserAndGroup s.user s.group s.supplementaryGroups s.execStart
+      }";
+      "scripted" = "${
+        nglib.maybeChangeUserAndGroup s.user s.group s.supplementaryGroups s.execStart
+      } ; sleep infinity";
+    }
+    .${s.type}
+  }
 ''


### PR DESCRIPTION
When `init.services.<name>.type` is set to `scripted`, init systems will keep the service active even after `execStart` exits. When set to `process` the service is only considered active while `execStart` is running.